### PR TITLE
[refactor] Group 관련 이름 변경

### DIFF
--- a/src/main/java/com/back/domain/checkList/itemAssign/entity/ItemAssign.java
+++ b/src/main/java/com/back/domain/checkList/itemAssign/entity/ItemAssign.java
@@ -1,11 +1,10 @@
 package com.back.domain.checkList.itemAssign.entity;
 
 import com.back.domain.checkList.checkList.entity.CheckListItem;
-import com.back.domain.group.groupMember.entity.GroupMember;
 import jakarta.persistence.*;
 import jdk.jfr.Description;
 import lombok.*;
-
+import com.back.domain.club.clubMember.entity.ClubMember;
 /**
  * 멤버를 checklistItem에 할당하는 엔티티
  */
@@ -16,7 +15,7 @@ import lombok.*;
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Table(
-        uniqueConstraints = @UniqueConstraint(columnNames = {"group_member_id", "check_list_item_id"})
+        uniqueConstraints = @UniqueConstraint(columnNames = {"club_member_id", "check_list_item_id"})
 )
 public class ItemAssign {
     @Id
@@ -26,9 +25,9 @@ public class ItemAssign {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "group_member_id", nullable = false)
+    @JoinColumn(name = "club_member_id", nullable = false)
     @Description("할당된 인원")
-    private GroupMember groupMember;
+    private ClubMember clubMember;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "check_list_item_id", nullable = false)

--- a/src/main/java/com/back/domain/club/club/entity/Club.java
+++ b/src/main/java/com/back/domain/club/club/entity/Club.java
@@ -1,6 +1,6 @@
-package com.back.domain.group.group.entity;
+package com.back.domain.club.club.entity;
 
-import com.back.domain.group.groupMember.entity.GroupMember;
+import com.back.domain.club.clubMember.entity.ClubMember;
 import com.back.domain.schedule.schedule.entity.Schedule;
 import jakarta.persistence.*;
 import jdk.jfr.Description;
@@ -16,7 +16,7 @@ import java.util.List;
 @Builder
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class Group {
+public class Club {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -76,12 +76,12 @@ public class Group {
   private boolean stats = true;
 
   @Description("구성원")
-  @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
-  private List<GroupMember> groupMembers = new ArrayList<>();
+  private List<ClubMember> clubMembers = new ArrayList<>();
 
   @Description("일정 목록")
-  @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
-  private List<Schedule> groupSchedules = new ArrayList<>();
+  private List<Schedule> clubSchedules = new ArrayList<>();
 }

--- a/src/main/java/com/back/domain/club/club/repository/ClubRepository.java
+++ b/src/main/java/com/back/domain/club/club/repository/ClubRepository.java
@@ -1,0 +1,8 @@
+package com.back.domain.club.club.repository;
+
+import com.back.domain.club.club.entity.Club;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubRepository extends JpaRepository<Club, Long> {
+
+}

--- a/src/main/java/com/back/domain/club/clubMember/entity/ClubMember.java
+++ b/src/main/java/com/back/domain/club/clubMember/entity/ClubMember.java
@@ -1,10 +1,10 @@
-package com.back.domain.group.groupMember.entity;
+package com.back.domain.club.clubMember.entity;
 
 import com.back.domain.checkList.itemAssign.entity.ItemAssign;
-import com.back.domain.group.group.entity.Group;
+import com.back.domain.club.club.entity.Club;
 import com.back.domain.member.member.entity.Member;
-import com.back.global.enums.GroupMemberRole;
-import com.back.global.enums.GroupMemberState;
+import com.back.global.enums.ClubMemberRole;
+import com.back.global.enums.ClubMemberState;
 import jakarta.persistence.*;
 import jdk.jfr.Description;
 import lombok.*;
@@ -17,7 +17,7 @@ import java.util.List;
 @Builder
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class GroupMember {
+public class ClubMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,17 +31,17 @@ public class GroupMember {
 
     @Description("역할")
     @Enumerated(EnumType.STRING)
-    private GroupMemberRole role;
+    private ClubMemberRole role;
 
     @Description("가입 상태")
     @Enumerated(EnumType.STRING)
-    private GroupMemberState state;
+    private ClubMemberState state;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "group_id", nullable = false)
-    private Group group;
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
 
     @Description("체크리스트 아이템 할당 정보")
-    @OneToMany(mappedBy = "groupMember", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "clubMember", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ItemAssign> itemAssigns;
 }

--- a/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
@@ -1,0 +1,8 @@
+package com.back.domain.club.clubMember.repository;
+
+import com.back.domain.club.clubMember.entity.ClubMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
+
+}

--- a/src/main/java/com/back/domain/group/group/repository/GroupRepository.java
+++ b/src/main/java/com/back/domain/group/group/repository/GroupRepository.java
@@ -1,8 +1,0 @@
-package com.back.domain.group.group.repository;
-
-import com.back.domain.group.group.entity.Group;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface GroupRepository extends JpaRepository<Group, Long> {
-
-}

--- a/src/main/java/com/back/domain/group/groupMember/repository/GroupMemberRepository.java
+++ b/src/main/java/com/back/domain/group/groupMember/repository/GroupMemberRepository.java
@@ -1,8 +1,0 @@
-package com.back.domain.group.groupMember.repository;
-
-import com.back.domain.group.groupMember.entity.GroupMember;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
-
-}

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -1,7 +1,7 @@
 package com.back.domain.member.member.entity;
 
 
-import com.back.domain.group.groupMember.entity.GroupMember;
+import com.back.domain.club.clubMember.entity.ClubMember;
 import com.back.domain.member.friend.entity.Friend;
 import com.back.domain.preset.preset.entity.Preset;
 import jakarta.persistence.*;
@@ -44,6 +44,6 @@ public class Member {
   private List<Friend> friendshipsAsMember2;
 
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<GroupMember> groupMembers; // 소속 그룹 목록
+  private List<ClubMember> clubMembers; // 소속 그룹 목록
 
 }

--- a/src/main/java/com/back/domain/schedule/schedule/entity/Schedule.java
+++ b/src/main/java/com/back/domain/schedule/schedule/entity/Schedule.java
@@ -1,6 +1,6 @@
 package com.back.domain.schedule.schedule.entity;
 
-import com.back.domain.group.group.entity.Group;
+import com.back.domain.club.club.entity.Club;
 import jakarta.persistence.*;
 import jdk.jfr.Description;
 import lombok.*;
@@ -37,7 +37,7 @@ public class Schedule {
     private String spot; //TODO : 나중에 지도 연동하면 좌표로 변경
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    private Group group; // 그룹 일정
+    private Club club; // 그룹 일정
 
 
 }

--- a/src/main/java/com/back/global/enums/ClubMemberRole.java
+++ b/src/main/java/com/back/global/enums/ClubMemberRole.java
@@ -1,13 +1,13 @@
 package com.back.global.enums;
 
-public enum GroupMemberRole {
+public enum ClubMemberRole {
     PARTICIPANT("일반 회원"),
     MANAGER("관리자"),
     HOST("소유자");
 
     private final String description;
 
-    GroupMemberRole(String description) {
+    ClubMemberRole(String description) {
         this.description = description;
     }
 

--- a/src/main/java/com/back/global/enums/ClubMemberState.java
+++ b/src/main/java/com/back/global/enums/ClubMemberState.java
@@ -1,13 +1,13 @@
 package com.back.global.enums;
 
-public enum GroupMemberState {
+public enum ClubMemberState {
     INVITED("초대됨"),
     JOINING("가입 중"),
     APPLYING("가입 신청"),
     WITHDRAWN("탈퇴");
 
     private final String description;
-    GroupMemberState(String description) {
+    ClubMemberState(String description) {
         this.description = description;
     }
     public String getDescription() {

--- a/src/main/java/com/back/global/springDoc/SpringDocConfig.java
+++ b/src/main/java/com/back/global/springDoc/SpringDocConfig.java
@@ -26,8 +26,8 @@ public class SpringDocConfig {
     @Bean
     public GroupedOpenApi groupApiV1() {
         return GroupedOpenApi.builder()
-                .group("api")
-                .pathsToMatch("/api/**")
+                .group("api-v1")
+                .pathsToMatch("/api/v1/**")
                 .build();
     }
 }


### PR DESCRIPTION
## 📢 기능 설명
- 그룹 도메인 이름 변경 (Group -> Club)
- 전체 코드에 반영
- 추가적으로 Spring doc Config 설정 일부 수정

<br>

## 연결된 issue
close #58 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 클럽(Club) 및 클럽 멤버(ClubMember) 관리 기능이 추가되었습니다.

* **리팩터링**
  * 기존 그룹(Group) 및 그룹 멤버(GroupMember) 관련 명칭이 클럽(Club) 및 클럽 멤버(ClubMember)로 일괄 변경되었습니다.
  * 관련 엔티티, 필드, 열거형(Enum), 저장소(Repository) 등이 모두 클럽 기반으로 변경되었습니다.

* **문서화**
  * OpenAPI 문서 그룹이 "api"에서 "api-v1"로, 경로가 "/api/**"에서 "/api/v1/**"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->