### PR TITLE
[Feat] 일정 목록 조회

### DIFF
--- a/src/main/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleController.java
+++ b/src/main/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleController.java
@@ -10,8 +10,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -24,9 +26,11 @@ public class ApiV1ScheduleController {
     @GetMapping("/clubs/{clubId}")
     @Operation(summary = "모임의 일정 목록 조회")
     public RsData<List<ScheduleDto>> getClubSchedules(
-            @PathVariable Long clubId
+            @PathVariable Long clubId,
+            @RequestParam(value = "startDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
     ) {
-        List<Schedule> schedule = scheduleService.getGroupSchedules(clubId);
+        List<Schedule> schedule = scheduleService.getClubSchedules(clubId, startDate, endDate);
         List<ScheduleDto> scheduleDtos = schedule.stream()
                 .map(ScheduleDto::new)
                 .toList();

--- a/src/main/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleController.java
+++ b/src/main/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleController.java
@@ -23,13 +23,19 @@ public class ApiV1ScheduleController {
 
     @GetMapping("/clubs/{clubId}")
     @Operation(summary = "모임의 일정 목록 조회")
-    public List<ScheduleDto> getClubSchedules(
+    public RsData<List<ScheduleDto>> getClubSchedules(
             @PathVariable Long clubId
     ) {
         List<Schedule> schedule = scheduleService.getGroupSchedules(clubId);
-        return schedule.stream()
+        List<ScheduleDto> scheduleDtos = schedule.stream()
                 .map(ScheduleDto::new)
                 .toList();
+
+        return RsData.of(
+                200,
+                "%s번 모임의 일정 목록이 조회되었습니다.".formatted(clubId),
+                scheduleDtos
+        );
     }
 
 

--- a/src/main/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleController.java
+++ b/src/main/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleController.java
@@ -12,12 +12,26 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/schedules")
 @RequiredArgsConstructor
 @Tag(name = "ApiV1ScheduleController", description = "일정 컨트롤러")
 public class ApiV1ScheduleController {
     private final ScheduleService scheduleService;
+
+    @GetMapping("/clubs/{clubId}")
+    @Operation(summary = "모임의 일정 목록 조회")
+    public List<ScheduleDto> getClubSchedules(
+            @PathVariable Long clubId
+    ) {
+        List<Schedule> schedule = scheduleService.getGroupSchedules(clubId);
+        return schedule.stream()
+                .map(ScheduleDto::new)
+                .toList();
+    }
+
 
     @GetMapping("/{scheduleId}")
     @Operation(summary = "일정 조회")

--- a/src/main/java/com/back/domain/schedule/schedule/entity/Schedule.java
+++ b/src/main/java/com/back/domain/schedule/schedule/entity/Schedule.java
@@ -39,6 +39,7 @@ public class Schedule {
     private String spot; //TODO : 나중에 지도 연동하면 좌표로 변경
 
     @Description("활성화 여부")
+    @Builder.Default
     private boolean isActive = true;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/back/domain/schedule/schedule/entity/Schedule.java
+++ b/src/main/java/com/back/domain/schedule/schedule/entity/Schedule.java
@@ -2,6 +2,7 @@ package com.back.domain.schedule.schedule.entity;
 
 import com.back.domain.checkList.checkList.entity.CheckList;
 import com.back.domain.club.club.entity.Club;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jdk.jfr.Description;
 import lombok.*;
@@ -45,6 +46,7 @@ public class Schedule {
 
     @Setter
     @OneToOne(mappedBy = "schedule", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JsonIgnore
     private CheckList checkList;
 
     // 일정 수정

--- a/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
@@ -17,5 +17,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     Optional<Schedule> findFirstByClubIdOrderByIdDesc(Long clubId);
 
     // 특정 모임의 일정 개수 조회
-    int countByClubId(Long clubId);
+    long countByClubId(Long clubId);
 }

--- a/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
@@ -3,9 +3,16 @@ package com.back.domain.schedule.schedule.repository;
 import com.back.domain.schedule.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    // 특정 모임의 일정 목록을 시작 날짜 기준으로 오름차순 정렬하여 조회
+    List<Schedule> findByClubIdOrderByStartDate(Long clubId);
+
+    // 특정 모임의 최신 일정을 ID 기준으로 내림차순 정렬하여 조회
     Optional<Schedule> findFirstByClubIdOrderByIdDesc(Long clubId);
+
+    // 특정 모임의 일정 개수 조회
     int countByClubId(Long clubId);
 }

--- a/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
@@ -2,7 +2,10 @@ package com.back.domain.schedule.schedule.repository;
 
 import com.back.domain.schedule.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,8 +13,19 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     // 특정 모임의 일정 목록을 시작 날짜 기준으로 오름차순 정렬하여 조회
     List<Schedule> findByClubIdOrderByStartDate(Long clubId);
 
-    // 특정 모임의 활성화된 일정 목록을 시작 날짜 기준으로 오름차순 정렬하여 조회 (비활성화 일정 제외)
-    List<Schedule> findByClubIdAndIsActiveTrueOrderByStartDate(Long clubId);
+    // 특정 모임의 활성화된 일정 중, 범위 내에 있는 목록을 시작 날짜 기준으로 오름차순 정렬하여 조회
+    @Query("""
+            SELECT s FROM Schedule s 
+            WHERE s.club.id = :clubId 
+            AND s.isActive = true 
+            AND s.startDate BETWEEN :startDateTime AND :endDateTime 
+            ORDER BY s.startDate
+            """)
+    List<Schedule> findSchedulesByClubAndDateRange(
+            @Param("clubId") Long clubId,
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
 
     // 특정 모임의 최신 일정을 ID 기준으로 내림차순 정렬하여 조회
     Optional<Schedule> findFirstByClubIdOrderByIdDesc(Long clubId);

--- a/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
@@ -10,6 +10,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     // 특정 모임의 일정 목록을 시작 날짜 기준으로 오름차순 정렬하여 조회
     List<Schedule> findByClubIdOrderByStartDate(Long clubId);
 
+    // 특정 모임의 활성화된 일정 목록을 시작 날짜 기준으로 오름차순 정렬하여 조회 (비활성화 일정 제외)
+    List<Schedule> findByClubIdAndIsActiveTrueOrderByStartDate(Long clubId);
+
     // 특정 모임의 최신 일정을 ID 기준으로 내림차순 정렬하여 조회
     Optional<Schedule> findFirstByClubIdOrderByIdDesc(Long clubId);
 

--- a/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
+++ b/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
@@ -62,7 +62,7 @@ public class ScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public int countClubSchedules(Long clubId) {
+    public long countClubSchedules(Long clubId) {
         return scheduleRepository.countByClubId(clubId);
     }
 

--- a/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
+++ b/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
@@ -26,15 +26,15 @@ public class ScheduleService {
     /**
      * 특정 모임의 일정 목록 조회
      * @param clubId
-     * @return
+     * @return schedules
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<Schedule> getGroupSchedules(Long clubId) {
         clubRepository.findById(clubId)
                 .orElseThrow(() -> new NoSuchElementException("%d번 모임은 존재하지 않습니다.".formatted(clubId)));
 
-        // 모임의 일정 목록 조회
-        return scheduleRepository.findByClubIdOrderByStartDate(clubId);
+        // 모임의 일정 목록 조회 (활성화된 일정만)
+        return scheduleRepository.findByClubIdAndIsActiveTrueOrderByStartDate(clubId);
     }
 
     /**

--- a/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
+++ b/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
@@ -34,8 +34,18 @@ public class ScheduleService {
         LocalDateTime endDateTime;
 
         if (startDate != null && endDate != null) {
+            // 시작일과 종료일이 모두 있는 경우, 해당 범위로 설정
             startDateTime = startDate.atStartOfDay();
             endDateTime = endDate.atTime(23, 59, 59);
+
+            validateDate(startDateTime, endDateTime);
+        } else if (startDate != null && endDate == null) {
+            // 시작일만 있는 경우, 해당 달의 1일부터 마지막 날까지 범위 설정
+            YearMonth month = YearMonth.from(startDate);
+
+            startDateTime = startDate.atStartOfDay();
+            endDateTime = month.atEndOfMonth().atTime(23, 59, 59);
+
             validateDate(startDateTime, endDateTime);
         } else {
             // 날짜 파라미터 없는 경우, 현재 달을 기준으로 설정

--- a/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
+++ b/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -22,6 +23,19 @@ public class ScheduleService {
     private final ClubRepository clubRepository;
     private final CheckListRepository checkListRepository;
 
+    /**
+     * 특정 모임의 일정 목록 조회
+     * @param clubId
+     * @return
+     */
+    @Transactional
+    public List<Schedule> getGroupSchedules(Long clubId) {
+        clubRepository.findById(clubId)
+                .orElseThrow(() -> new NoSuchElementException("%d번 모임은 존재하지 않습니다.".formatted(clubId)));
+
+        // 모임의 일정 목록 조회
+        return scheduleRepository.findByClubIdOrderByStartDate(clubId);
+    }
 
     /**
      * 일정 조회

--- a/src/main/java/com/back/global/initData/TestInitData.java
+++ b/src/main/java/com/back/global/initData/TestInitData.java
@@ -4,6 +4,7 @@ import com.back.domain.checkList.checkList.entity.CheckList;
 import com.back.domain.checkList.checkList.repository.CheckListRepository;
 import com.back.domain.club.club.entity.Club;
 import com.back.domain.club.club.repository.ClubRepository;
+import com.back.domain.club.clubMember.entity.ClubMember;
 import com.back.domain.club.clubMember.repository.ClubMemberRepository;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.entity.MemberInfo;

--- a/src/main/java/com/back/global/initData/TestInitData.java
+++ b/src/main/java/com/back/global/initData/TestInitData.java
@@ -154,8 +154,6 @@ public class TestInitData {
                     .club(club1)
                     .build();
             scheduleRepository.save(schedule);
-
-            System.out.println("모임 %d 일정 : ".formatted(schedule.getId()) + schedule.getStartDate() + " ~ " + schedule.getEndDate());
         }
 
         // 모임 2의 일정 초기 데이터
@@ -179,6 +177,7 @@ public class TestInitData {
                 .spot("강릉")
                 .club(club2)
                 .build();
+        schedule3.deactivate();
         scheduleRepository.save(schedule3);
 
         CheckList checkList = CheckList.builder()

--- a/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
@@ -36,7 +36,7 @@ class ApiV1ScheduleControllerTest {
     private ParameterObjectNamingStrategyCustomizer parameterObjectNamingStrategyCustomizer;
 
     @Test
-    @DisplayName("일정 목록 조회")
+    @DisplayName("일정 목록 조회 - 날짜 파라미터 없는 경우 현재 달 기준")
     void trl1() throws Exception {
         Long clubId = 1L;
 
@@ -44,7 +44,7 @@ class ApiV1ScheduleControllerTest {
                 .perform(get("/api/v1/schedules/clubs/" + clubId))
                 .andDo(print());
 
-        List<Schedule> schedules = scheduleService.getGroupSchedules(clubId);
+        List<Schedule> schedules = scheduleService.getClubSchedules(clubId, null, null);
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))

--- a/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
@@ -50,18 +50,20 @@ class ApiV1ScheduleControllerTest {
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))
                 .andExpect(handler().methodName("getClubSchedules"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(schedules.size()));
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("%s번 모임의 일정 목록이 조회되었습니다.".formatted(clubId)))
+                .andExpect(jsonPath("$.data.length()").value(schedules.size()));
 
         for (int i = 0; i < schedules.size(); i++) {
             Schedule schedule = schedules.get(i);
 
             resultActions
-                    .andExpect(jsonPath("$[%d].id".formatted(i)).value(schedule.getId()))
-                    .andExpect(jsonPath("$[%d].title".formatted(i)).value(schedule.getTitle()))
-                    .andExpect(jsonPath("$[%d].content".formatted(i)).value(schedule.getContent()))
-                    .andExpect(jsonPath("$[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$[%d].spot".formatted(i)).value(schedule.getSpot()));
+                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.getId()))
+                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.getTitle()))
+                    .andExpect(jsonPath("$.data[%d].content".formatted(i)).value(schedule.getContent()))
+                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].spot".formatted(i)).value(schedule.getSpot()));
         }
     }
 
@@ -198,7 +200,7 @@ class ApiV1ScheduleControllerTest {
         Schedule schedule = scheduleService.getScheduleById(scheduleId);
 
         Long clubId = schedule.getClub().getId();
-        int preCnt = scheduleService.countClubSchedules(clubId);
+        long preCnt = scheduleService.countClubSchedules(clubId);
 
         ResultActions resultActions = mockMvc
                 .perform(delete("/api/v1/schedules/" + scheduleId))
@@ -211,7 +213,7 @@ class ApiV1ScheduleControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("%d번 일정이 삭제되었습니다.".formatted(scheduleId)));
 
-        int afterCnt = scheduleService.countClubSchedules(clubId);
+        long afterCnt = scheduleService.countClubSchedules(clubId);
         assertThat(afterCnt).isEqualTo(preCnt - 1);
     }
 
@@ -222,7 +224,7 @@ class ApiV1ScheduleControllerTest {
         Schedule schedule = scheduleService.getScheduleById(scheduleId);
 
         Long clubId = schedule.getClub().getId();
-        int preCnt = scheduleService.countClubSchedules(clubId);
+        long preCnt = scheduleService.countClubSchedules(clubId);
 
         ResultActions resultActions = mockMvc
                 .perform(delete("/api/v1/schedules/" + scheduleId))
@@ -236,7 +238,7 @@ class ApiV1ScheduleControllerTest {
                 .andExpect(jsonPath("$.message").value("%d번 일정이 삭제되었습니다.".formatted(scheduleId)));
 
         // 일정이 삭제가 아닌 비활성화 되었는지 확인
-        int afterCnt = scheduleService.countClubSchedules(clubId);
+        long afterCnt = scheduleService.countClubSchedules(clubId);
         assertThat(afterCnt).isEqualTo(preCnt);
 
         Schedule updatedSchedule = scheduleService.getScheduleById(scheduleId);

--- a/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +46,77 @@ class ApiV1ScheduleControllerTest {
                 .andDo(print());
 
         List<Schedule> schedules = scheduleService.getClubSchedules(clubId, null, null);
+
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ScheduleController.class))
+                .andExpect(handler().methodName("getClubSchedules"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("%s번 모임의 일정 목록이 조회되었습니다.".formatted(clubId)))
+                .andExpect(jsonPath("$.data.length()").value(schedules.size()));
+
+        for (int i = 0; i < schedules.size(); i++) {
+            Schedule schedule = schedules.get(i);
+
+            resultActions
+                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.getId()))
+                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.getTitle()))
+                    .andExpect(jsonPath("$.data[%d].content".formatted(i)).value(schedule.getContent()))
+                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].spot".formatted(i)).value(schedule.getSpot()));
+        }
+    }
+
+    @Test
+    @DisplayName("일정 목록 조회 - 날짜 파라미터 있는 경우")
+    void trl2() throws Exception {
+        Long clubId = 1L;
+        String startDateStr = "2025-08-01";
+        String endDateStr = "2025-08-31";
+
+        ResultActions resultActions = mockMvc
+                .perform(get("/api/v1/schedules/clubs/" + clubId)
+                        .param("startDate", startDateStr)
+                        .param("endDate", endDateStr))
+                .andDo(print());
+
+        List<Schedule> schedules = scheduleService.getClubSchedules(clubId, LocalDate.parse(startDateStr), LocalDate.parse(endDateStr));
+
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ScheduleController.class))
+                .andExpect(handler().methodName("getClubSchedules"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("%s번 모임의 일정 목록이 조회되었습니다.".formatted(clubId)))
+                .andExpect(jsonPath("$.data.length()").value(schedules.size()));
+
+        for (int i = 0; i < schedules.size(); i++) {
+            Schedule schedule = schedules.get(i);
+
+            resultActions
+                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.getId()))
+                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.getTitle()))
+                    .andExpect(jsonPath("$.data[%d].content".formatted(i)).value(schedule.getContent()))
+                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].spot".formatted(i)).value(schedule.getSpot()));
+        }
+    }
+
+    @Test
+    @DisplayName("일정 목록 조회 - 시작일 파라미터만 있는 경우")
+    void trl3() throws Exception {
+        Long clubId = 1L;
+        String startDateStr = "2025-07-15";
+        String endDateStr = "2025-07-31";
+
+        ResultActions resultActions = mockMvc
+                .perform(get("/api/v1/schedules/clubs/" + clubId)
+                        .param("startDate", startDateStr))
+                .andDo(print());
+
+        List<Schedule> schedules = scheduleService.getClubSchedules(clubId, LocalDate.parse(startDateStr), LocalDate.parse(endDateStr));
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))

--- a/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -32,6 +34,36 @@ class ApiV1ScheduleControllerTest {
     private ScheduleService scheduleService;
     @Autowired
     private ParameterObjectNamingStrategyCustomizer parameterObjectNamingStrategyCustomizer;
+
+    @Test
+    @DisplayName("일정 목록 조회")
+    void trl1() throws Exception {
+        Long clubId = 1L;
+
+        ResultActions resultActions = mockMvc
+                .perform(get("/api/v1/schedules/clubs/" + clubId))
+                .andDo(print());
+
+        List<Schedule> schedules = scheduleService.getGroupSchedules(clubId);
+
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ScheduleController.class))
+                .andExpect(handler().methodName("getClubSchedules"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(schedules.size()));
+
+        for (int i = 0; i < schedules.size(); i++) {
+            Schedule schedule = schedules.get(i);
+
+            resultActions
+                    .andExpect(jsonPath("$[%d].id".formatted(i)).value(schedule.getId()))
+                    .andExpect(jsonPath("$[%d].title".formatted(i)).value(schedule.getTitle()))
+                    .andExpect(jsonPath("$[%d].content".formatted(i)).value(schedule.getContent()))
+                    .andExpect(jsonPath("$[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$[%d].spot".formatted(i)).value(schedule.getSpot()));
+        }
+    }
 
     @Test
     @DisplayName("일정 조회")


### PR DESCRIPTION
## 📢 기능 설명
- 그룹의 일정 목록 조회 (지정한 기간 내 활성화된 일정)

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #43 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
- [x] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 특정 모임(club)의 활성 일정 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 일정 데이터 조회 시 활성 상태 및 시작일 기준 정렬 기능이 개선되었습니다.
  * 일정 조회 시 시작일과 종료일을 기준으로 필터링할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 일정 데이터 초기화 시 불필요한 디버그 출력이 제거되고, 일부 일정의 활성화 상태가 명확히 처리되었습니다.

* **테스트**
  * 일정 목록 조회 API의 정상 동작을 검증하는 다양한 날짜 파라미터 케이스 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->