### PR TITLE
 [feat] 모임 소개 - 누구나

### DIFF
--- a/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
+++ b/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
@@ -60,4 +60,11 @@ public class ApiV1ClubController {
         clubService.deleteClub(clubId);
         return new RsData<>(204, "클럽이 삭제됐습니다.", null);
     }
+
+    @GetMapping("/{clubId}/intro")
+    @Operation(summary = "클럽 소개 조회")
+    public RsData<ClubControllerDtos.ClubIntroResponse> getClubIntro(@PathVariable Long clubId) {
+        ClubControllerDtos.ClubIntroResponse intro = clubService.getClubIntro(clubId);
+        return new RsData<>(200, "클럽 소개 정보가 조회됐습니다.", intro);
+    }
 }

--- a/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
+++ b/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
@@ -74,4 +74,26 @@ public class ClubControllerDtos {
     ){}
 
 
+    /**
+     * 클럽 소개 조회 응답을 위한 DTO 클래스입니다.
+     * 클럽의 ID, 이름, 소개, 카테고리, 주요 장소, 최대 인원 수, 이벤트 유형,
+     * 시작일, 종료일, 공개 여부 및 리더 ID를 포함합니다.
+     */
+    public static record ClubIntroResponse(
+            Long clubId,
+            String name,
+            String bio,
+            String category,
+            String mainSpot,
+            int maximumCapacity,
+            boolean recruitingStatus,
+            String eventType,
+            String startDate,
+            String endDate,
+            Boolean isPublic,
+            String imageUrl,
+            Long leaderId,
+            String leaderName
+    ) {
+    }
 }

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -5,6 +5,7 @@ import com.back.domain.club.club.entity.Club;
 import com.back.domain.club.club.repository.ClubRepository;
 import com.back.domain.club.clubMember.entity.ClubMember;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
 import com.back.global.aws.S3Service;
 import com.back.global.enums.ClubCategory;
 import com.back.global.enums.ClubMemberRole;
@@ -26,7 +27,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ClubService {
     private final ClubRepository clubRepository;
-    //private final MemberService memberService;
+    private final MemberService memberService;
     private final S3Service s3Service;
 
     /**
@@ -152,5 +153,36 @@ public class ClubService {
 
         // 클럽 삭제
         club.changeState(false); // 클럽 상태를 비활성화로 변경
+    }
+
+    /**
+     * 클럽 소개 정보를 조회합니다.
+     * @param clubId 클럽 ID
+     * @return 클럽 소개 정보 DTO
+     */
+    public ClubControllerDtos.ClubIntroResponse getClubIntro(Long clubId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new ServiceException(404, "해당 ID의 클럽을 찾을 수 없습니다."));
+
+        Member leader = memberService.findById(club.getLeaderId())
+                .orElseThrow(() -> new ServiceException(404, "해당 ID의 클럽 리더를 찾을 수 없습니다."));
+
+
+        return new ClubControllerDtos.ClubIntroResponse(
+                club.getId(),
+                club.getName(),
+                club.getBio(),
+                club.getCategory().toString(),
+                club.getMainSpot(),
+                club.getMaximumCapacity(),
+                club.isRecruitingStatus(),
+                club.getEventType().toString(),
+                club.getStartDate().toString(),
+                club.getEndDate().toString(),
+                club.isPublic(),
+                club.getImageUrl(),
+                club.getLeaderId(),
+                leader.getNickname()
+        );
     }
 }

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -135,4 +135,8 @@ public class MemberService {
 
         return memberInfo.get().getMember();
     }
+
+    public Optional<Member> findById(Long id) {
+        return memberRepository.findById(id);
+    }
 }

--- a/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
+++ b/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
@@ -514,10 +514,10 @@ class ApiV1ClubControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubController.class))
-                .andExpect(handler().methodName("getClubInfo"))
+                .andExpect(handler().methodName("getClubIntro"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("클럽 소개 정보가 조회되었습니다."))
+                .andExpect(jsonPath("$.message").value("클럽 소개 정보가 조회됐습니다."))
                 .andExpect(jsonPath("$.data.clubId").value(club.getId()))
                 .andExpect(jsonPath("$.data.name").value(club.getName()))
                 .andExpect(jsonPath("$.data.bio").value(club.getBio()))
@@ -532,5 +532,27 @@ class ApiV1ClubControllerTest {
                 .andExpect(jsonPath("$.data.imageUrl").value(club.getImageUrl()))
                 .andExpect(jsonPath("$.data.leaderId").value(club.getLeaderId()))
                 .andExpect(jsonPath("$.data.leaderName").value(dto.nickname()));
+    }
+
+    @Test
+    @DisplayName("모임 소개 정보 조회 - 존재하지 않는 클럽")
+    void getNonExistentClubIntro() throws Exception {
+        // given
+        Long nonExistentClubId = 999L; // 존재하지 않는 클럽 ID
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                multipart("/api/v1/clubs/" + nonExistentClubId + "/intro")
+                        .with(request -> {
+                            request.setMethod("GET"); // GET 메소드로 요청
+                            return request;
+                        })
+        ).andDo(print());
+
+        // then
+        resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value("해당 ID의 클럽을 찾을 수 없습니다."));
     }
 }

--- a/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
+++ b/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
@@ -518,6 +518,7 @@ class ApiV1ClubControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("클럽 소개 정보가 조회되었습니다."))
+                .andExpect(jsonPath("$.data.clubId").value(club.getId()))
                 .andExpect(jsonPath("$.data.name").value(club.getName()))
                 .andExpect(jsonPath("$.data.bio").value(club.getBio()))
                 .andExpect(jsonPath("$.data.category").value(club.getCategory().name()))


### PR DESCRIPTION
## 📢 기능 설명
- 모임 소개 정보 반환하는 엔드포인트와 로직 작성
- 관련 테스트 케이스 작성
- MemberService에서 id로 멤버 서치하는 메서드 추가
<br>

## 연결된 issue
close #22 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 클럽 소개 정보를 조회할 수 있는 GET API 엔드포인트(`/api/v1/clubs/{clubId}/intro`)가 추가되었습니다. 클럽의 이름, 소개, 카테고리, 주요 장소, 최대 인원, 모집 상태, 이벤트 유형, 기간, 공개 여부, 이미지, 리더 정보 등 상세 정보를 확인할 수 있습니다.

* **테스트**
  * 클럽 소개 조회 기능에 대한 정상 및 예외 케이스 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->