### PR TITLE
[refactor] 모임 생성 시 참여자 포함

### DIFF
--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -23,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
@@ -93,10 +94,8 @@ public class ClubService {
         // 클럽 멤버 설정
         Arrays.stream(reqBody.clubMembers()).forEach(memberInfo -> {
             // 멤버 ID로 Member 엔티티 조회
-//          Member member = memberService.findById(memberInfo.id())
-//              .orElseThrow(() -> new NoSuchElementException("ID " + memberInfo.id() + "에 해당하는 멤버를 찾을 수 없습니다."));
-
-            Member member = new Member(); // TODO : 임시로 Member 객체 생성, 실제로는 memberService.findById(memberInfo.id())를 사용해야 함
+            Member member = memberService.findById(memberInfo.id())
+              .orElseThrow(() -> new NoSuchElementException("ID " + memberInfo.id() + "에 해당하는 멤버를 찾을 수 없습니다."));
 
             // ClubMember 엔티티 생성
             ClubMember clubMember = ClubMember.builder()
@@ -108,7 +107,6 @@ public class ClubService {
             // 연관관계 편의 메서드를 사용하여 Club에 ClubMember 추가
             club.addClubMember(clubMember);
         });
-
         return club;
     }
 


### PR DESCRIPTION
## 📢 기능 설명
- 모임 생성 시 requestbody로 초기 참여자 정보를 받아서 저장할 수 있도록 로직 수정
- 관련 테스트 케이스 보강
<br>

## 연결된 issue
close #89 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
