### PR TITLE
 [feat] 참여자 삭제

### DIFF
--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -26,4 +26,15 @@ public class ApiV1ClubMemberController {
 
         return RsData.of(201, "클럽에 멤버가 추가됐습니다.", null);
     }
+
+    @DeleteMapping("/{memberId}")
+    @Operation(summary = "클럽에서 멤버 탈퇴")
+    public RsData<Void> withdrawMemberFromClub(
+            @PathVariable Long clubId,
+            @PathVariable Long memberId
+    ) {
+        clubMemberService.withdrawMemberFromClub(clubId, memberId);
+
+        return RsData.of(200, "클럽에서 멤버가 탈퇴됐습니다.", null);
+    }
 }

--- a/src/main/java/com/back/domain/club/clubMember/entity/ClubMember.java
+++ b/src/main/java/com/back/domain/club/clubMember/entity/ClubMember.java
@@ -50,4 +50,8 @@ public class ClubMember {
         this.itemAssigns.add(itemAssign);
         itemAssign.setClubMember(this);
     }
+
+    public void updateState(ClubMemberState newState) {
+        this.state = newState;
+    }
 }

--- a/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
@@ -1,11 +1,14 @@
 package com.back.domain.club.clubMember.repository;
 
+import com.back.domain.club.club.entity.Club;
 import com.back.domain.club.clubMember.entity.ClubMember;
+import com.back.domain.member.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<ClubMember> findAllByClubId(Long clubId);
@@ -18,4 +21,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 """)
     List<String> findExistingEmails(@Param("clubId") Long clubId,
                                     @Param("emails") List<String> emails);
+
+    Optional<ClubMember> findByClubAndMember(Club club, Member member);
 }

--- a/src/main/java/com/back/global/rq/Rq.java
+++ b/src/main/java/com/back/global/rq/Rq.java
@@ -1,13 +1,10 @@
 package com.back.global.rq;
 
 
-import com.back.global.security.SecurityUser;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -335,5 +336,121 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
     }
 
+    @Test
+    @DisplayName("클럽 멤버 탈퇴")
+    void withdrawMemberFromClub() throws Exception {
+        // given
+        // 테스트 클럽 생성
+        Club club = clubService.createClub(
+                Club.builder()
+                        .name("테스트 그룹")
+                        .bio("테스트 그룹 설명")
+                        .category(ClubCategory.STUDY)
+                        .mainSpot("서울")
+                        .maximumCapacity(10)
+                        .eventType(EventType.ONE_TIME)
+                        .startDate(LocalDate.of(2023, 10, 1))
+                        .endDate(LocalDate.of(2023, 10, 31))
+                        .isPublic(true)
+                        .leaderId(1L)
+                        .build()
+        );
+
+        // 추가할 멤버 (testInitData의 멤버 사용)
+        Member member1 = memberService.findById(2L).orElseThrow(
+                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
+        );
+
+        // 클럽에 멤버 추가
+        clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
+
+        assertThat(club.getClubMembers().size()).isEqualTo(1); // 클럽에 멤버가 1명 추가되었는지 확인
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                        delete("/api/v1/clubs/" + club.getId() + "/members/" + member1.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
+                .andExpect(handler().methodName("withdrawMemberFromClub"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("클럽에서 멤버가 탈퇴됐습니다."));
+
+        // 추가 검증: 클럽에서 멤버가 실제로 삭제되지 않고 state가 withdrawn로 변경되었는지 확인
+        club = clubService.getClubById(club.getId()).orElseThrow(
+                () -> new IllegalStateException("클럽이 존재하지 않습니다.")
+        );
+
+        assertThat(club.getClubMembers().size()).isEqualTo(1); // 클럽에 멤버가 여전히 존재해야 함
+        assertThat(club.getClubMembers().get(0).getMember().getEmail()).isEqualTo(member1.getEmail());
+        assertThat(club.getClubMembers().get(0).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT);
+        assertThat(club.getClubMembers().get(0).getState()).isEqualTo("WITHDRAWN"); // 상태가 WITHDRAWN으로 변경되었는지 확인
+    }
+
+    @Test
+    @DisplayName("클럽 멤버 탈퇴 - 클럽이 존재하지 않을 때")
+    void withdrawMemberFromClub_ClubNotFound() throws Exception {
+        // given
+        String nonExistentClubId = "9999"; // 존재하지 않는 클럽 ID
+        Long memberId = 2L; // 임의의 멤버 ID
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                        delete("/api/v1/clubs/" + nonExistentClubId + "/members/" + memberId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
+                .andExpect(handler().methodName("withdrawMemberFromClub"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("클럽 멤버 탈퇴 - 멤버가 클럽에 존재하지 않을 때")
+    void withdrawMemberFromClub_MemberNotFound() throws Exception {
+        // given
+        // 테스트 클럽 생성
+        Club club = clubService.createClub(
+                Club.builder()
+                        .name("테스트 그룹")
+                        .bio("테스트 그룹 설명")
+                        .category(ClubCategory.STUDY)
+                        .mainSpot("서울")
+                        .maximumCapacity(10)
+                        .eventType(EventType.ONE_TIME)
+                        .startDate(LocalDate.of(2023, 10, 1))
+                        .endDate(LocalDate.of(2023, 10, 31))
+                        .isPublic(true)
+                        .leaderId(1L)
+                        .build()
+        );
+
+        Long nonExistentMemberId = 9999L; // 존재하지 않는 멤버 ID
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                        delete("/api/v1/clubs/" + club.getId() + "/members/" + nonExistentMemberId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
+                .andExpect(handler().methodName("withdrawMemberFromClub"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+    }
 }
 

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -8,6 +8,7 @@ import com.back.domain.member.member.service.MemberService;
 import com.back.global.aws.S3Service;
 import com.back.global.enums.ClubCategory;
 import com.back.global.enums.ClubMemberRole;
+import com.back.global.enums.ClubMemberState;
 import com.back.global.enums.EventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -389,7 +390,7 @@ class ApiV1ClubMemberControllerTest {
         assertThat(club.getClubMembers().size()).isEqualTo(1); // 클럽에 멤버가 여전히 존재해야 함
         assertThat(club.getClubMembers().get(0).getMember().getEmail()).isEqualTo(member1.getEmail());
         assertThat(club.getClubMembers().get(0).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT);
-        assertThat(club.getClubMembers().get(0).getState()).isEqualTo("WITHDRAWN"); // 상태가 WITHDRAWN으로 변경되었는지 확인
+        assertThat(club.getClubMembers().get(0).getState()).isEqualTo(ClubMemberState.WITHDRAWN); // 상태가 WITHDRAWN으로 변경되었는지 확인
     }
 
     @Test
@@ -448,9 +449,9 @@ class ApiV1ClubMemberControllerTest {
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
                 .andExpect(handler().methodName("withdrawMemberFromClub"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400))
-                .andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value("멤버가 존재하지 않습니다."));
     }
 }
 


### PR DESCRIPTION
## 📢 기능 설명
- 멤버의 클럽 탈퇴 엔드포인트 작성 (실제로 삭제하지 않고 멤버 상태만 WITHDRAW 로 변경)
- 관련 로직 작성
- 테스트케이스 작성
<br>

## 연결된 issue
close #38
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 클럽 멤버가 클럽에서 탈퇴할 수 있는 API가 추가되었습니다.

* **버그 수정**
  * 클럽 탈퇴 시 멤버가 실제로 삭제되지 않고 상태가 'WITHDRAWN'으로 변경됩니다.

* **테스트**
  * 클럽 멤버 탈퇴 기능에 대한 정상 동작, 클럽 미존재, 멤버 미존재 케이스 테스트가 추가되었습니다.

* **기타**
  * 사용되지 않는 보안 관련 import가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->