### PR TITLE
 [feat] 참여자 권한 설정

### DIFF
--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -37,4 +37,16 @@ public class ApiV1ClubMemberController {
 
         return RsData.of(200, "클럽에서 멤버가 탈퇴됐습니다.", null);
     }
+
+    @PutMapping("/{memberId}/role")
+    @Operation(summary = "클럽 멤버 권한 변경")
+    public RsData<Void> changeMemberRole(
+            @PathVariable Long clubId,
+            @PathVariable Long memberId,
+            @RequestBody @Valid ClubMemberDtos.ClubMemberRoleChangeRequest reqBody
+    ) {
+        clubMemberService.changeMemberRole(clubId, memberId, reqBody.role());
+
+        return RsData.of(200, "멤버의 권한이 변경됐습니다.", null);
+    }
 }

--- a/src/main/java/com/back/domain/club/clubMember/dtos/ClubMemberDtos.java
+++ b/src/main/java/com/back/domain/club/clubMember/dtos/ClubMemberDtos.java
@@ -35,4 +35,9 @@ public class ClubMemberDtos {
             @NotEmpty
             List<ClubMemberRegisterInfo> members
     ){}
+
+    public static record ClubMemberRoleChangeRequest (
+            @NotBlank
+            String role
+    ){}
 }

--- a/src/main/java/com/back/domain/club/clubMember/entity/ClubMember.java
+++ b/src/main/java/com/back/domain/club/clubMember/entity/ClubMember.java
@@ -54,4 +54,6 @@ public class ClubMember {
     public void updateState(ClubMemberState newState) {
         this.state = newState;
     }
+
+    public void updateRole(ClubMemberRole newRole) { this.role = newRole; }
 }

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -10,6 +10,7 @@ import com.back.domain.member.member.service.MemberService;
 import com.back.global.enums.ClubMemberRole;
 import com.back.global.enums.ClubMemberState;
 import com.back.global.exception.ServiceException;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -103,6 +104,26 @@ public class ClubMemberService {
 
         // 클럽에서 멤버 탈퇴
         clubMember.updateState(ClubMemberState.WITHDRAWN);
+        clubMemberRepository.save(clubMember);
+    }
+
+    /**
+     * 클럽 멤버의 역할을 변경합니다.
+     * @param clubId 클럽 ID
+     * @param memberId 멤버 ID
+     * @param role 변경할 역할
+     */
+    @Transactional
+    public void changeMemberRole(Long clubId, Long memberId, @NotBlank String role) {
+        Club club = clubService.getClubById(clubId)
+                .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
+        Member member = memberService.findById(memberId)
+                .orElseThrow(() -> new ServiceException(404, "멤버가 존재하지 않습니다."));
+        ClubMember clubMember = clubMemberRepository.findByClubAndMember(club, member)
+                .orElseThrow(() -> new ServiceException(404, "멤버가 존재하지 않습니다."));
+
+        // 역할 변경
+        clubMember.updateRole(ClubMemberRole.fromString(role.toUpperCase()));
         clubMemberRepository.save(clubMember);
     }
 }

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -115,6 +115,8 @@ public class ClubMemberService {
      */
     @Transactional
     public void changeMemberRole(Long clubId, Long memberId, @NotBlank String role) {
+        // TODO : 유저 권한 체크
+
         Club club = clubService.getClubById(clubId)
                 .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
         Member member = memberService.findById(memberId)

--- a/src/main/java/com/back/global/enums/CheckListItemCategory.java
+++ b/src/main/java/com/back/global/enums/CheckListItemCategory.java
@@ -1,5 +1,7 @@
 package com.back.global.enums;
 
+import com.back.global.exception.ServiceException;
+
 public enum CheckListItemCategory {
     // 준비물
     // 예약
@@ -18,5 +20,14 @@ public enum CheckListItemCategory {
 
     public String getDescription() {
         return description;
+    }
+
+    public static CheckListItemCategory fromString(String category) {
+        for (CheckListItemCategory checkListItemCategory : CheckListItemCategory.values()) {
+            if (checkListItemCategory.name().equalsIgnoreCase(category)) {
+                return checkListItemCategory;
+            }
+        }
+        throw new ServiceException(400, "Unknown Item category: " + category);
     }
 }

--- a/src/main/java/com/back/global/enums/ClubCategory.java
+++ b/src/main/java/com/back/global/enums/ClubCategory.java
@@ -1,5 +1,7 @@
 package com.back.global.enums;
 
+import com.back.global.exception.ServiceException;
+
 public enum ClubCategory {
     STUDY("스터디"),
     HOBBY("취미"),
@@ -26,6 +28,6 @@ public enum ClubCategory {
                 return clubCategory;
             }
         }
-        throw new IllegalArgumentException("Unknown category: " + category);
+        throw new ServiceException(400, "Unknown Club category: " + category);
     }
 }

--- a/src/main/java/com/back/global/enums/ClubMemberRole.java
+++ b/src/main/java/com/back/global/enums/ClubMemberRole.java
@@ -23,6 +23,6 @@ public enum ClubMemberRole {
                 return clubMemberRole;
             }
         }
-        throw new ServiceException(400, "Unknown role: " + role);
+        throw new ServiceException(400, "Unknown Member role: " + role);
     }
 }

--- a/src/main/java/com/back/global/enums/ClubMemberRole.java
+++ b/src/main/java/com/back/global/enums/ClubMemberRole.java
@@ -1,5 +1,7 @@
 package com.back.global.enums;
 
+import com.back.global.exception.ServiceException;
+
 public enum ClubMemberRole {
     PARTICIPANT("일반 회원"),
     MANAGER("관리자"),
@@ -21,6 +23,6 @@ public enum ClubMemberRole {
                 return clubMemberRole;
             }
         }
-        throw new IllegalArgumentException("Unknown role: " + role);
+        throw new ServiceException(400, "Unknown role: " + role);
     }
 }

--- a/src/main/java/com/back/global/enums/ClubMemberState.java
+++ b/src/main/java/com/back/global/enums/ClubMemberState.java
@@ -1,5 +1,7 @@
 package com.back.global.enums;
 
+import com.back.global.exception.ServiceException;
+
 public enum ClubMemberState {
     INVITED("초대됨"),
     JOINING("가입 중"),
@@ -12,5 +14,14 @@ public enum ClubMemberState {
     }
     public String getDescription() {
         return description;
+    }
+
+    public static ClubMemberState fromString(String state) {
+        for (ClubMemberState clubMemberState : ClubMemberState.values()) {
+            if (clubMemberState.name().equalsIgnoreCase(state)) {
+                return clubMemberState;
+            }
+        }
+        throw new ServiceException(400, "Unknown Member state: " + state);
     }
 }

--- a/src/main/java/com/back/global/enums/EventType.java
+++ b/src/main/java/com/back/global/enums/EventType.java
@@ -1,5 +1,7 @@
 package com.back.global.enums;
 
+import com.back.global.exception.ServiceException;
+
 public enum EventType {
     // 일회성, 단기, 장기
     ONE_TIME("일회성"), // 한 번만 열리는 모임
@@ -22,7 +24,7 @@ public enum EventType {
                 return type;
             }
         }
-        throw new IllegalArgumentException("Unknown event type: " + eventType);
+        throw new ServiceException(400, "Unknown event type: " + eventType);
     }
 
 }

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -616,7 +616,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(handler().methodName("changeMemberRole"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
-                .andExpect(jsonPath("$.message").value("Unknown role: INVALID_ROLE"));
+                .andExpect(jsonPath("$.message").value("Unknown Member role: INVALID_ROLE"));
     }
 }
 


### PR DESCRIPTION
## 📢 기능 설명
- 참여자 권한 설정 엔드포인트 작성
- 관련 로직 작성
- 테스트 케이스 작성
- enums 의 fromString method에서 잘못된 타입일 시 일관되게 ServiceException을 발생시키도록 변경
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #37 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
