### PR TITLE
 [feat] 참여자 목록 조회

### DIFF
--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -49,4 +49,15 @@ public class ApiV1ClubMemberController {
 
         return RsData.of(200, "멤버의 권한이 변경됐습니다.", null);
     }
+
+    @GetMapping
+    @Operation(summary = "클럽 멤버 목록 조회")
+    public RsData<ClubMemberDtos.ClubMemberResponse> getClubMembers(
+            @PathVariable Long clubId,
+            @RequestParam(required = false) String state // Optional: 상태 필터링
+    ) {
+        ClubMemberDtos.ClubMemberResponse clubMemberResponse = clubMemberService.getClubMembers(clubId, state);
+
+        return RsData.of(200, "클럽 멤버 목록이 조회됐습니다.", clubMemberResponse);
+    }
 }

--- a/src/main/java/com/back/domain/club/clubMember/dtos/ClubMemberDtos.java
+++ b/src/main/java/com/back/domain/club/clubMember/dtos/ClubMemberDtos.java
@@ -44,7 +44,7 @@ public class ClubMemberDtos {
             String role
     ){}
 
-    public static record ClubMemberResponse(
+    public static record ClubMemberInfo(
             Long clubMemberid,
             Long memberId,
             String nickname,
@@ -54,5 +54,9 @@ public class ClubMemberDtos {
             MemberType memberType,
             String profileImageUrl,
             ClubMemberState state
+    ) {}
+
+    public static record ClubMemberResponse(
+            List<ClubMemberInfo> clubMembers
     ) {}
 }

--- a/src/main/java/com/back/domain/club/clubMember/dtos/ClubMemberDtos.java
+++ b/src/main/java/com/back/domain/club/clubMember/dtos/ClubMemberDtos.java
@@ -1,5 +1,8 @@
 package com.back.domain.club.clubMember.dtos;
 
+import com.back.domain.member.member.MemberType;
+import com.back.global.enums.ClubMemberRole;
+import com.back.global.enums.ClubMemberState;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 
@@ -40,4 +43,16 @@ public class ClubMemberDtos {
             @NotBlank
             String role
     ){}
+
+    public static record ClubMemberResponse(
+            Long clubMemberid,
+            Long memberId,
+            String nickname,
+            String tag,
+            ClubMemberRole role,
+            String email,
+            MemberType memberType,
+            String profileImageUrl,
+            ClubMemberState state
+    ) {}
 }

--- a/src/main/java/com/back/domain/club/clubMember/dtos/ClubMemberDtos.java
+++ b/src/main/java/com/back/domain/club/clubMember/dtos/ClubMemberDtos.java
@@ -45,7 +45,7 @@ public class ClubMemberDtos {
     ){}
 
     public static record ClubMemberInfo(
-            Long clubMemberid,
+            Long clubMemberId,
             Long memberId,
             String nickname,
             String tag,
@@ -57,6 +57,6 @@ public class ClubMemberDtos {
     ) {}
 
     public static record ClubMemberResponse(
-            List<ClubMemberInfo> clubMembers
+            List<ClubMemberInfo> members
     ) {}
 }

--- a/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
@@ -3,6 +3,7 @@ package com.back.domain.club.clubMember.repository;
 import com.back.domain.club.club.entity.Club;
 import com.back.domain.club.clubMember.entity.ClubMember;
 import com.back.domain.member.member.entity.Member;
+import com.back.global.enums.ClubMemberState;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +24,8 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
                                     @Param("emails") List<String> emails);
 
     Optional<ClubMember> findByClubAndMember(Club club, Member member);
+
+    List<ClubMember> findByClubAndState(Club club, ClubMemberState clubMemberState);
+
+    List<ClubMember> findByClub(Club club);
 }

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -33,19 +33,19 @@ public class ClubMemberService {
      * @param role 클럽 멤버 역할
      */
     @Transactional
-    public void addMemberToClub(Long clubId, Member member, ClubMemberRole role) {
+    public ClubMember addMemberToClub(Long clubId, Member member, ClubMemberRole role) {
         Club club = clubService.getClubById(clubId)
                 .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
 
         ClubMember clubMember = ClubMember.builder()
                 .member(member)
                 .role(role) // 기본 역할은 MEMBER
-                .state(ClubMemberState.INVITED) // 기본 상태는 JOINED
+                .state(ClubMemberState.INVITED) // 기본 상태는 INVITED
                 .build();
 
         club.addClubMember(clubMember);
 
-        clubMemberRepository.save(clubMember);
+        return clubMemberRepository.save(clubMember);
     }
 
     /**
@@ -128,4 +128,5 @@ public class ClubMemberService {
         clubMember.updateRole(ClubMemberRole.fromString(role.toUpperCase()));
         clubMemberRepository.save(clubMember);
     }
+
 }

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -6,6 +6,7 @@ import com.back.domain.club.clubMember.dtos.ClubMemberDtos;
 import com.back.domain.club.clubMember.entity.ClubMember;
 import com.back.domain.club.clubMember.repository.ClubMemberRepository;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.entity.MemberInfo;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.enums.ClubMemberRole;
 import com.back.global.enums.ClubMemberState;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Service
@@ -129,4 +131,50 @@ public class ClubMemberService {
         clubMemberRepository.save(clubMember);
     }
 
+    /**
+     * 클럽의 멤버 목록을 조회합니다.
+     * @param clubId 클럽 ID
+     * @param state 상태 필터링 (선택적)
+     * @return 클럽 멤버 목록 DTO
+     */
+    @Transactional(readOnly = true)
+    public ClubMemberDtos.ClubMemberResponse getClubMembers(Long clubId, String state) {
+        // 클럽 확인
+        Club club = clubService.getClubById(clubId)
+                .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
+
+        // 클럽멤버 목록 반환
+        List<ClubMember> clubMembers;
+        if(state != null){
+            clubMembers = clubMemberRepository.findByClubAndState(club, ClubMemberState.fromString(state));
+        }
+        else {
+            clubMembers = clubMemberRepository.findByClub(club);
+        }
+
+        // 클럽 멤버 정보를 DTO로 변환
+        List<ClubMemberDtos.ClubMemberInfo> memberInfos = clubMembers.stream()
+                .map(clubMember -> {
+                    Member m = clubMember.getMember();
+
+                    return new ClubMemberDtos.ClubMemberInfo(
+                            clubMember.getId(),
+                            m.getId(),
+                            m.getNickname(),
+                            m.getTag(),
+                            clubMember.getRole(),
+                            Optional.ofNullable(m.getMemberInfo())
+                                    .map(MemberInfo::getEmail)
+                                    .orElse(""),
+                            m.getMemberType(),
+                            Optional.ofNullable(m.getMemberInfo())
+                                    .map(MemberInfo::getProfileImageUrl)
+                                    .orElse(""),
+                            clubMember.getState()
+                    );
+                }).toList();
+
+        return new ClubMemberDtos.ClubMemberResponse(memberInfos);
+
+    }
 }

--- a/src/main/java/com/back/global/initData/TestInitData.java
+++ b/src/main/java/com/back/global/initData/TestInitData.java
@@ -13,6 +13,7 @@ import com.back.domain.club.clubMember.repository.ClubMemberRepository;
 import com.back.domain.member.friend.entity.Friend;
 import com.back.domain.member.friend.entity.FriendStatus;
 import com.back.domain.member.friend.repository.FriendRepository;
+import com.back.domain.member.member.MemberType;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.entity.MemberInfo;
 import com.back.domain.member.member.repository.MemberInfoRepository;
@@ -526,6 +527,8 @@ public class TestInitData {
         Member member = Member.builder()
                 .nickname(nickname)
                 .password(password)
+                .memberType(MemberType.MEMBER)
+                .tag(UUID.randomUUID().toString().substring(0, 5))
                 .build();
         memberRepository.save(member);
 

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -626,7 +626,7 @@ class ApiV1ClubMemberControllerTest {
 
     @Test
     @DisplayName("참여자 목록 반환 - state 필터 없음")
-    void getMembersOfClub() throws Exception {
+    void getClubMembers() throws Exception {
         // given
         // 테스트 클럽 생성
         Club club = clubService.createClub(
@@ -679,45 +679,46 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("getMembersOfClub"))
+                .andExpect(handler().methodName("getClubMembers"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("클럽 멤버 목록이 조회됐습니다."))
                 .andExpect(jsonPath("$.data.members.length()").value(3)) // 멤버가 3명인지 확인
 
-                .andExpect(jsonPath("$.data[0].members.clubMemberId").value(clubMember1.getId()))
-                .andExpect(jsonPath("$.data[0].members.memberId").value(member1.getId()))
-                .andExpect(jsonPath("$.data[0].members.nickname").value(member1.getNickname()))
-                .andExpect(jsonPath("$.data[0].members.tag").value(member1.getTag()))
-                .andExpect(jsonPath("$.data[0].members.role").value(ClubMemberRole.PARTICIPANT))
-                .andExpect(jsonPath("$.data[0].members.email").value(member1.getEmail()))
-                .andExpect(jsonPath("$.data[0].members.memberType").value(member1.getMemberType()))
-                .andExpect(jsonPath("$.data[0].members.profileImageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
-                .andExpect(jsonPath("$.data[0].members.state").value(clubMember1.getState()))
+                .andExpect(jsonPath("$.data.members[0].clubMemberId").value(clubMember1.getId()))
+                .andExpect(jsonPath("$.data.members[0].memberId").value(member1.getId()))
+                .andExpect(jsonPath("$.data.members[0].nickname").value(member1.getNickname()))
+                .andExpect(jsonPath("$.data.members[0].tag").value(member1.getTag()))
+                .andExpect(jsonPath("$.data.members[0].role").value(ClubMemberRole.PARTICIPANT.name()))
+                .andExpect(jsonPath("$.data.members[0].email").value(member1.getEmail()))
+                .andExpect(jsonPath("$.data.members[0].memberType").value(member1.getMemberType().name()))
+                .andExpect(jsonPath("$.data.members[0].profileImageUrl").value(""))
+                .andExpect(jsonPath("$.data.members[0].state").value(clubMember1.getState().name()))
 
-                .andExpect(jsonPath("$.data[1].members.clubMemberId").value(clubMember2.getId()))
-                .andExpect(jsonPath("$.data[1].members.memberId").value(member2.getId()))
-                .andExpect(jsonPath("$.data[1].members.nickname").value(member2.getNickname()))
-                .andExpect(jsonPath("$.data[1].members.tag").value(member2.getTag()))
-                .andExpect(jsonPath("$.data[1].members.role").value(ClubMemberRole.MANAGER))
-                .andExpect(jsonPath("$.data[1].members.email").value(member2.getEmail()))
-                .andExpect(jsonPath("$.data[1].members.memberType").value(member2.getMemberType()))
-                .andExpect(jsonPath("$.data[1].members.profileImageUrl").value(member2.getMemberInfo().getProfileImageUrl()))
-                .andExpect(jsonPath("$.data[1].members.state").value(clubMember2.getState()))
+                .andExpect(jsonPath("$.data.members[1].clubMemberId").value(clubMember2.getId()))
+                .andExpect(jsonPath("$.data.members[1].memberId").value(member2.getId()))
+                .andExpect(jsonPath("$.data.members[1].nickname").value(member2.getNickname()))
+                .andExpect(jsonPath("$.data.members[1].tag").value(member2.getTag()))
+                .andExpect(jsonPath("$.data.members[1].role").value(ClubMemberRole.MANAGER.name()))
+                .andExpect(jsonPath("$.data.members[1].email").value(member2.getEmail()))
+                .andExpect(jsonPath("$.data.members[1].memberType").value(member2.getMemberType().name()))
+                .andExpect(jsonPath("$.data.members[1].profileImageUrl").value(""))
+                .andExpect(jsonPath("$.data.members[1].state").value(clubMember2.getState().name()))
 
-                .andExpect(jsonPath("$.data[2].members.clubMemberId").value(nonMemberClubMember.getId()))
-                .andExpect(jsonPath("$.data[2].members.memberId").value(nonMember.getId()))
-                .andExpect(jsonPath("$.data[2].members.nickname").value(nonMember.getNickname()))
-                .andExpect(jsonPath("$.data[2].members.tag").value(nonMember.getTag()))
-                .andExpect(jsonPath("$.data[2].members.role").value(ClubMemberRole.PARTICIPANT))
-                .andExpect(jsonPath("$.data[2].members.email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[2].members.memberType").value(nonMember.getMemberType()))
-                .andExpect(jsonPath("$.data[2].members.profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[2].members.state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인}
+                .andExpect(jsonPath("$.data.members[2].clubMemberId").value(nonMemberClubMember.getId()))
+                .andExpect(jsonPath("$.data.members[2].memberId").value(nonMember.getId()))
+                .andExpect(jsonPath("$.data.members[2].nickname").value(nonMember.getNickname()))
+                .andExpect(jsonPath("$.data.members[2].tag").value(nonMember.getTag()))
+                .andExpect(jsonPath("$.data.members[2].role").value(ClubMemberRole.PARTICIPANT.name()))
+                .andExpect(jsonPath("$.data.members[2].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data.members[2].memberType").value(nonMember.getMemberType().name()))
+                .andExpect(jsonPath("$.data.members[2].profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data.members[2].state").value(nonMemberClubMember.getState().name())); // 비회원의 상태 확인
     }
+
     @Test
     @DisplayName("참여자 목록 반환 - state 필터 (INVITED)")
-    void getMembersOfClub_stateFiltered() throws Exception {
+    void getClubMembers_stateFiltered() throws Exception {
         // given
         // 테스트 클럽 생성
         Club club = clubService.createClub(
@@ -774,35 +775,36 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("getMembersOfClub"))
+                .andExpect(handler().methodName("getClubMembers"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("클럽 멤버 목록이 조회됐습니다."))
                 .andExpect(jsonPath("$.data.members.length()").value(2)) // 멤버가 2명인지 확인
 
-                .andExpect(jsonPath("$.data[0].members.memberId").value(member1.getId()))
-                .andExpect(jsonPath("$.data[0].members.nickname").value(member1.getNickname()))
-                .andExpect(jsonPath("$.data[0].members.tag").value(member1.getTag()))
-                .andExpect(jsonPath("$.data[0].members.role").value(ClubMemberRole.PARTICIPANT))
-                .andExpect(jsonPath("$.data[0].members.email").value(member1.getEmail()))
-                .andExpect(jsonPath("$.data[0].members.memberType").value(member1.getMemberType()))
-                .andExpect(jsonPath("$.data[0].members.profileImageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
-                .andExpect(jsonPath("$.data[0].members.state").value(clubMember1.getState()))
+                .andExpect(jsonPath("$.data.members[0].clubMemberId").value(clubMember1.getId()))
+                .andExpect(jsonPath("$.data.members[0].memberId").value(member1.getId()))
+                .andExpect(jsonPath("$.data.members[0].nickname").value(member1.getNickname()))
+                .andExpect(jsonPath("$.data.members[0].tag").value(member1.getTag()))
+                .andExpect(jsonPath("$.data.members[0].role").value(ClubMemberRole.PARTICIPANT.name()))
+                .andExpect(jsonPath("$.data.members[0].email").value(member1.getEmail()))
+                .andExpect(jsonPath("$.data.members[0].memberType").value(member1.getMemberType().name()))
+                .andExpect(jsonPath("$.data.members[0].profileImageUrl").value(""))
+                .andExpect(jsonPath("$.data.members[0].state").value(clubMember1.getState().name()))
 
-                .andExpect(jsonPath("$.data[1].members.clubMemberId").value(nonMemberClubMember.getId()))
-                .andExpect(jsonPath("$.data[1].members.memberId").value(nonMember.getId()))
-                .andExpect(jsonPath("$.data[1].members.nickname").value(nonMember.getNickname()))
-                .andExpect(jsonPath("$.data[1].members.tag").value(nonMember.getTag()))
-                .andExpect(jsonPath("$.data[1].members.role").value(ClubMemberRole.PARTICIPANT))
-                .andExpect(jsonPath("$.data[1].members.email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[1].members.memberType").value(nonMember.getMemberType()))
-                .andExpect(jsonPath("$.data[1].members.profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[1].members.state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인
+                .andExpect(jsonPath("$.data.members[1].clubMemberId").value(nonMemberClubMember.getId()))
+                .andExpect(jsonPath("$.data.members[1].memberId").value(nonMember.getId()))
+                .andExpect(jsonPath("$.data.members[1].nickname").value(nonMember.getNickname()))
+                .andExpect(jsonPath("$.data.members[1].tag").value(nonMember.getTag()))
+                .andExpect(jsonPath("$.data.members[1].role").value(ClubMemberRole.PARTICIPANT.name()))
+                .andExpect(jsonPath("$.data.members[1].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data.members[1].memberType").value(nonMember.getMemberType().name()))
+                .andExpect(jsonPath("$.data.members[1].profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data.members[1].state").value(nonMemberClubMember.getState().name())); // 비회원의 상태 확인
     }
 
     @Test
     @DisplayName("참여자 목록 반환 - 존재하지 않는 클럽")
-    void getMembersOfClub_InvalidClubId() throws Exception {
+    void getClubMembers_InvalidClubId() throws Exception {
         // given
         int invalidClubId = 9999; // 잘못된 클럽 ID
 
@@ -816,7 +818,7 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("getMembersOfClub"))
+                .andExpect(handler().methodName("getClubMembers"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("Invalid club ID format."));
@@ -824,7 +826,7 @@ class ApiV1ClubMemberControllerTest {
 
     @Test
     @DisplayName("참여자 목록 반환 - 잘못된 state 필터")
-    void getMembersOfClub_InvalidStateFilter() throws Exception {
+    void getClubMembers_InvalidStateFilter() throws Exception {
         // given
         // 테스트 클럽 생성
         Club club = clubService.createClub(
@@ -852,7 +854,7 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("getMembersOfClub"))
+                .andExpect(handler().methodName("getClubMembers"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("Unknown Member state: INVALID_STATE"));

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -682,40 +682,39 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(handler().methodName("getMembersOfClub"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("클럽 멤버 목록을 반환합니다."))
-                .andExpect(jsonPath("$.data.length()").value(3)) // 멤버가 2명인지 확인
+                .andExpect(jsonPath("$.message").value("클럽 멤버 목록이 조회됐습니다."))
+                .andExpect(jsonPath("$.data.members.length()").value(3)) // 멤버가 3명인지 확인
 
-                .andExpect(jsonPath("$.data[0].clubMemberId").value(clubMember1.getId()))
-                .andExpect(jsonPath("$.data[0].memberId").value(member1.getId()))
-                .andExpect(jsonPath("$.data[0].nickname").value(member1.getNickname()))
-                .andExpect(jsonPath("$.data[0].tag").value(member1.getTag()))
-                .andExpect(jsonPath("$.data[0].role").value(ClubMemberRole.PARTICIPANT))
-                .andExpect(jsonPath("$.data[0].email").value(member1.getEmail()))
-                .andExpect(jsonPath("$.data[0].memberType").value(member1.getMemberType()))
-                .andExpect(jsonPath("$.data[0].profileImageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
-                .andExpect(jsonPath("$.data[0].state").value(clubMember1.getState()))
+                .andExpect(jsonPath("$.data[0].members.clubMemberId").value(clubMember1.getId()))
+                .andExpect(jsonPath("$.data[0].members.memberId").value(member1.getId()))
+                .andExpect(jsonPath("$.data[0].members.nickname").value(member1.getNickname()))
+                .andExpect(jsonPath("$.data[0].members.tag").value(member1.getTag()))
+                .andExpect(jsonPath("$.data[0].members.role").value(ClubMemberRole.PARTICIPANT))
+                .andExpect(jsonPath("$.data[0].members.email").value(member1.getEmail()))
+                .andExpect(jsonPath("$.data[0].members.memberType").value(member1.getMemberType()))
+                .andExpect(jsonPath("$.data[0].members.profileImageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
+                .andExpect(jsonPath("$.data[0].members.state").value(clubMember1.getState()))
 
-                .andExpect(jsonPath("$.data[1].clubMemberId").value(clubMember2.getId()))
-                .andExpect(jsonPath("$.data[1].memberId").value(member2.getId()))
-                .andExpect(jsonPath("$.data[1].nickname").value(member2.getNickname()))
-                .andExpect(jsonPath("$.data[1].tag").value(member2.getTag()))
-                .andExpect(jsonPath("$.data[1].role").value(ClubMemberRole.MANAGER))
-                .andExpect(jsonPath("$.data[1].email").value(member2.getEmail()))
-                .andExpect(jsonPath("$.data[1].memberType").value(member2.getMemberType()))
-                .andExpect(jsonPath("$.data[1].profileImageUrl").value(member2.getMemberInfo().getProfileImageUrl()))
-                .andExpect(jsonPath("$.data[1].state").value(clubMember2.getState()))
+                .andExpect(jsonPath("$.data[1].members.clubMemberId").value(clubMember2.getId()))
+                .andExpect(jsonPath("$.data[1].members.memberId").value(member2.getId()))
+                .andExpect(jsonPath("$.data[1].members.nickname").value(member2.getNickname()))
+                .andExpect(jsonPath("$.data[1].members.tag").value(member2.getTag()))
+                .andExpect(jsonPath("$.data[1].members.role").value(ClubMemberRole.MANAGER))
+                .andExpect(jsonPath("$.data[1].members.email").value(member2.getEmail()))
+                .andExpect(jsonPath("$.data[1].members.memberType").value(member2.getMemberType()))
+                .andExpect(jsonPath("$.data[1].members.profileImageUrl").value(member2.getMemberInfo().getProfileImageUrl()))
+                .andExpect(jsonPath("$.data[1].members.state").value(clubMember2.getState()))
 
-                .andExpect(jsonPath("$.data[2].clubMemberId").value(nonMemberClubMember.getId()))
-                .andExpect(jsonPath("$.data[2].memberId").value(nonMember.getId()))
-                .andExpect(jsonPath("$.data[2].nickname").value(nonMember.getNickname()))
-                .andExpect(jsonPath("$.data[2].tag").value(nonMember.getTag()))
-                .andExpect(jsonPath("$.data[2].role").value(ClubMemberRole.PARTICIPANT))
-                .andExpect(jsonPath("$.data[2].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[2].memberType").value(nonMember.getMemberType()))
-                .andExpect(jsonPath("$.data[2].profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[2].state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인
+                .andExpect(jsonPath("$.data[2].members.clubMemberId").value(nonMemberClubMember.getId()))
+                .andExpect(jsonPath("$.data[2].members.memberId").value(nonMember.getId()))
+                .andExpect(jsonPath("$.data[2].members.nickname").value(nonMember.getNickname()))
+                .andExpect(jsonPath("$.data[2].members.tag").value(nonMember.getTag()))
+                .andExpect(jsonPath("$.data[2].members.role").value(ClubMemberRole.PARTICIPANT))
+                .andExpect(jsonPath("$.data[2].members.email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[2].members.memberType").value(nonMember.getMemberType()))
+                .andExpect(jsonPath("$.data[2].members.profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[2].members.state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인}
     }
-
     @Test
     @DisplayName("참여자 목록 반환 - state 필터 (INVITED)")
     void getMembersOfClub_stateFiltered() throws Exception {
@@ -778,29 +777,27 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(handler().methodName("getMembersOfClub"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("클럽 멤버 목록을 반환합니다."))
-                .andExpect(jsonPath("$.data.length()").value(3)) // 멤버가 2명인지 확인
+                .andExpect(jsonPath("$.message").value("클럽 멤버 목록이 조회됐습니다."))
+                .andExpect(jsonPath("$.data.members.length()").value(2)) // 멤버가 2명인지 확인
 
-                .andExpect(jsonPath("$.data[0].clubMemberId").value(clubMember1.getId()))
-                .andExpect(jsonPath("$.data[0].memberId").value(member1.getId()))
-                .andExpect(jsonPath("$.data[0].nickname").value(member1.getNickname()))
-                .andExpect(jsonPath("$.data[0].tag").value(member1.getTag()))
-                .andExpect(jsonPath("$.data[0].role").value(ClubMemberRole.PARTICIPANT))
-                .andExpect(jsonPath("$.data[0].email").value(member1.getEmail()))
-                .andExpect(jsonPath("$.data[0].memberType").value(member1.getMemberType()))
-                .andExpect(jsonPath("$.data[0].profileImageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
-                .andExpect(jsonPath("$.data[0].state").value(clubMember1.getState()))
+                .andExpect(jsonPath("$.data[0].members.memberId").value(member1.getId()))
+                .andExpect(jsonPath("$.data[0].members.nickname").value(member1.getNickname()))
+                .andExpect(jsonPath("$.data[0].members.tag").value(member1.getTag()))
+                .andExpect(jsonPath("$.data[0].members.role").value(ClubMemberRole.PARTICIPANT))
+                .andExpect(jsonPath("$.data[0].members.email").value(member1.getEmail()))
+                .andExpect(jsonPath("$.data[0].members.memberType").value(member1.getMemberType()))
+                .andExpect(jsonPath("$.data[0].members.profileImageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
+                .andExpect(jsonPath("$.data[0].members.state").value(clubMember1.getState()))
 
-                .andExpect(jsonPath("$.data[1].clubMemberId").value(nonMemberClubMember.getId()))
-                .andExpect(jsonPath("$.data[1].memberId").value(nonMember.getId()))
-                .andExpect(jsonPath("$.data[1].nickname").value(nonMember.getNickname()))
-                .andExpect(jsonPath("$.data[1].tag").value(nonMember.getTag()))
-                .andExpect(jsonPath("$.data[1].role").value(ClubMemberRole.PARTICIPANT))
-                .andExpect(jsonPath("$.data[1].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[1].memberType").value(nonMember.getMemberType()))
-                .andExpect(jsonPath("$.data[1].profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[1].state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인
-
+                .andExpect(jsonPath("$.data[1].members.clubMemberId").value(nonMemberClubMember.getId()))
+                .andExpect(jsonPath("$.data[1].members.memberId").value(nonMember.getId()))
+                .andExpect(jsonPath("$.data[1].members.nickname").value(nonMember.getNickname()))
+                .andExpect(jsonPath("$.data[1].members.tag").value(nonMember.getTag()))
+                .andExpect(jsonPath("$.data[1].members.role").value(ClubMemberRole.PARTICIPANT))
+                .andExpect(jsonPath("$.data[1].members.email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[1].members.memberType").value(nonMember.getMemberType()))
+                .andExpect(jsonPath("$.data[1].members.profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[1].members.state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인
     }
 
     @Test

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -689,30 +689,30 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(jsonPath("$.data[0].memberId").value(member1.getId()))
                 .andExpect(jsonPath("$.data[0].nickname").value(member1.getNickname()))
                 .andExpect(jsonPath("$.data[0].tag").value(member1.getTag()))
-                .andExpect(jsonPath("$.data[0].role").value("PARTICIPANT"))
+                .andExpect(jsonPath("$.data[0].role").value(ClubMemberRole.PARTICIPANT))
                 .andExpect(jsonPath("$.data[0].email").value(member1.getEmail()))
-                .andExpect(jsonPath("$.data[0].memberType").value(member1.getMemberType().toString()))
-                .andExpect(jsonPath("$.data[0].imageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
+                .andExpect(jsonPath("$.data[0].memberType").value(member1.getMemberType()))
+                .andExpect(jsonPath("$.data[0].profileImageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
                 .andExpect(jsonPath("$.data[0].state").value(clubMember1.getState()))
 
                 .andExpect(jsonPath("$.data[1].clubMemberId").value(clubMember2.getId()))
                 .andExpect(jsonPath("$.data[1].memberId").value(member2.getId()))
                 .andExpect(jsonPath("$.data[1].nickname").value(member2.getNickname()))
                 .andExpect(jsonPath("$.data[1].tag").value(member2.getTag()))
-                .andExpect(jsonPath("$.data[1].role").value("MANAGER"))
+                .andExpect(jsonPath("$.data[1].role").value(ClubMemberRole.MANAGER))
                 .andExpect(jsonPath("$.data[1].email").value(member2.getEmail()))
-                .andExpect(jsonPath("$.data[1].memberType").value(member2.getMemberType().toString()))
-                .andExpect(jsonPath("$.data[1].imageUrl").value(member2.getMemberInfo().getProfileImageUrl()))
+                .andExpect(jsonPath("$.data[1].memberType").value(member2.getMemberType()))
+                .andExpect(jsonPath("$.data[1].profileImageUrl").value(member2.getMemberInfo().getProfileImageUrl()))
                 .andExpect(jsonPath("$.data[1].state").value(clubMember2.getState()))
 
                 .andExpect(jsonPath("$.data[2].clubMemberId").value(nonMemberClubMember.getId()))
                 .andExpect(jsonPath("$.data[2].memberId").value(nonMember.getId()))
                 .andExpect(jsonPath("$.data[2].nickname").value(nonMember.getNickname()))
                 .andExpect(jsonPath("$.data[2].tag").value(nonMember.getTag()))
-                .andExpect(jsonPath("$.data[2].role").value("PARTICIPANT"))
+                .andExpect(jsonPath("$.data[2].role").value(ClubMemberRole.PARTICIPANT))
                 .andExpect(jsonPath("$.data[2].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[2].memberType").value(nonMember.getMemberType().toString()))
-                .andExpect(jsonPath("$.data[2].imageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[2].memberType").value(nonMember.getMemberType()))
+                .andExpect(jsonPath("$.data[2].profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
                 .andExpect(jsonPath("$.data[2].state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인
     }
 
@@ -785,20 +785,20 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(jsonPath("$.data[0].memberId").value(member1.getId()))
                 .andExpect(jsonPath("$.data[0].nickname").value(member1.getNickname()))
                 .andExpect(jsonPath("$.data[0].tag").value(member1.getTag()))
-                .andExpect(jsonPath("$.data[0].role").value("PARTICIPANT"))
+                .andExpect(jsonPath("$.data[0].role").value(ClubMemberRole.PARTICIPANT))
                 .andExpect(jsonPath("$.data[0].email").value(member1.getEmail()))
-                .andExpect(jsonPath("$.data[0].memberType").value(member1.getMemberType().toString()))
-                .andExpect(jsonPath("$.data[0].imageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
+                .andExpect(jsonPath("$.data[0].memberType").value(member1.getMemberType()))
+                .andExpect(jsonPath("$.data[0].profileImageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
                 .andExpect(jsonPath("$.data[0].state").value(clubMember1.getState()))
 
                 .andExpect(jsonPath("$.data[1].clubMemberId").value(nonMemberClubMember.getId()))
                 .andExpect(jsonPath("$.data[1].memberId").value(nonMember.getId()))
                 .andExpect(jsonPath("$.data[1].nickname").value(nonMember.getNickname()))
                 .andExpect(jsonPath("$.data[1].tag").value(nonMember.getTag()))
-                .andExpect(jsonPath("$.data[1].role").value("PARTICIPANT"))
+                .andExpect(jsonPath("$.data[1].role").value(ClubMemberRole.PARTICIPANT))
                 .andExpect(jsonPath("$.data[1].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data[1].memberType").value(nonMember.getMemberType().toString()))
-                .andExpect(jsonPath("$.data[1].imageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[1].memberType").value(nonMember.getMemberType()))
+                .andExpect(jsonPath("$.data[1].profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
                 .andExpect(jsonPath("$.data[1].state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인
 
     }

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -819,9 +819,9 @@ class ApiV1ClubMemberControllerTest {
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
                 .andExpect(handler().methodName("getClubMembers"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400))
-                .andExpect(jsonPath("$.message").value("Invalid club ID format."));
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
     }
 
     @Test

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -2,7 +2,10 @@ package com.back.domain.club.clubMember.controller;
 
 import com.back.domain.club.club.entity.Club;
 import com.back.domain.club.club.service.ClubService;
+import com.back.domain.club.clubMember.entity.ClubMember;
+import com.back.domain.club.clubMember.repository.ClubMemberRepository;
 import com.back.domain.club.clubMember.service.ClubMemberService;
+import com.back.domain.member.member.MemberType;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.aws.S3Service;
@@ -42,6 +45,8 @@ class ApiV1ClubMemberControllerTest {
     private ClubMemberService clubMemberService;
     @Autowired
     private MemberService memberService;
+    @Autowired
+    private ClubMemberRepository clubMemberRepository;
 
     @MockitoBean
     private S3Service s3Service; // S3Service는 MockBean으로 주입하여 실제 S3와의 통신을 피합니다.
@@ -258,7 +263,7 @@ class ApiV1ClubMemberControllerTest {
     }
 
     @Test
-    @DisplayName("클럽에 멤버 추가 - 클럽이 존재하지 않을 때")
+    @DisplayName("클럽에 멤버 추가 - 존재하지 않는 클럽")
     void addMemberToClub_ClubNotFound() throws Exception {
         // given
         String nonExistentClubId = "9999"; // 존재하지 않는 클럽 ID
@@ -393,7 +398,7 @@ class ApiV1ClubMemberControllerTest {
     }
 
     @Test
-    @DisplayName("클럽 멤버 탈퇴 - 클럽이 존재하지 않을 때")
+    @DisplayName("클럽 멤버 탈퇴 - 존재하지 않는 클럽")
     void withdrawMemberFromClub_ClubNotFound() throws Exception {
         // given
         String nonExistentClubId = "9999"; // 존재하지 않는 클럽 ID
@@ -510,7 +515,7 @@ class ApiV1ClubMemberControllerTest {
     }
 
     @Test
-    @DisplayName("참여자 권한 변경 - 클럽이 존재하지 않을 때")
+    @DisplayName("참여자 권한 변경 - 존재하지 않는 클럽")
     void changeMemberRole_ClubNotFound() throws Exception {
         // given
         String nonExistentClubId = "9999"; // 존재하지 않는 클럽 ID
@@ -617,6 +622,243 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("Unknown Member role: INVALID_ROLE"));
+    }
+
+    @Test
+    @DisplayName("참여자 목록 반환 - state 필터 없음")
+    void getMembersOfClub() throws Exception {
+        // given
+        // 테스트 클럽 생성
+        Club club = clubService.createClub(
+                Club.builder()
+                        .name("테스트 그룹")
+                        .bio("테스트 그룹 설명")
+                        .category(ClubCategory.STUDY)
+                        .mainSpot("서울")
+                        .maximumCapacity(10)
+                        .eventType(EventType.ONE_TIME)
+                        .startDate(LocalDate.of(2023, 10, 1))
+                        .endDate(LocalDate.of(2023, 10, 31))
+                        .isPublic(true)
+                        .leaderId(1L)
+                        .build()
+        );
+
+        // 추가할 멤버 (testInitData의 멤버 사용)
+        Member member1 = memberService.findById(2L).orElseThrow(
+                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
+        );
+
+        Member member2 = memberService.findById(3L).orElseThrow(
+                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
+        );
+
+        // 비회원 멤버 추가
+        Member nonMember = Member.builder()
+                .id(4L)
+                .nickname("비회원")
+                .password("password")
+                .memberType(MemberType.GUEST)
+                .tag("123456")
+                .build();
+
+        // 클럽에 멤버 추가
+        ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
+        ClubMember clubMember2 = clubMemberService.addMemberToClub(club.getId(), member2, ClubMemberRole.MANAGER);
+        ClubMember nonMemberClubMember = clubMemberService.addMemberToClub(club.getId(), nonMember, ClubMemberRole.PARTICIPANT);
+
+        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 2명 추가되었는지 확인
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                        get("/api/v1/clubs/" + club.getId() + "/members")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
+                .andExpect(handler().methodName("getMembersOfClub"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("클럽 멤버 목록을 반환합니다."))
+                .andExpect(jsonPath("$.data.length()").value(3)) // 멤버가 2명인지 확인
+
+                .andExpect(jsonPath("$.data[0].clubMemberId").value(clubMember1.getId()))
+                .andExpect(jsonPath("$.data[0].memberId").value(member1.getId()))
+                .andExpect(jsonPath("$.data[0].nickname").value(member1.getNickname()))
+                .andExpect(jsonPath("$.data[0].tag").value(member1.getTag()))
+                .andExpect(jsonPath("$.data[0].role").value("PARTICIPANT"))
+                .andExpect(jsonPath("$.data[0].email").value(member1.getEmail()))
+                .andExpect(jsonPath("$.data[0].memberType").value(member1.getMemberType().toString()))
+                .andExpect(jsonPath("$.data[0].imageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
+                .andExpect(jsonPath("$.data[0].state").value(clubMember1.getState()))
+
+                .andExpect(jsonPath("$.data[1].clubMemberId").value(clubMember2.getId()))
+                .andExpect(jsonPath("$.data[1].memberId").value(member2.getId()))
+                .andExpect(jsonPath("$.data[1].nickname").value(member2.getNickname()))
+                .andExpect(jsonPath("$.data[1].tag").value(member2.getTag()))
+                .andExpect(jsonPath("$.data[1].role").value("MANAGER"))
+                .andExpect(jsonPath("$.data[1].email").value(member2.getEmail()))
+                .andExpect(jsonPath("$.data[1].memberType").value(member2.getMemberType().toString()))
+                .andExpect(jsonPath("$.data[1].imageUrl").value(member2.getMemberInfo().getProfileImageUrl()))
+                .andExpect(jsonPath("$.data[1].state").value(clubMember2.getState()))
+
+                .andExpect(jsonPath("$.data[2].clubMemberId").value(nonMemberClubMember.getId()))
+                .andExpect(jsonPath("$.data[2].memberId").value(nonMember.getId()))
+                .andExpect(jsonPath("$.data[2].nickname").value(nonMember.getNickname()))
+                .andExpect(jsonPath("$.data[2].tag").value(nonMember.getTag()))
+                .andExpect(jsonPath("$.data[2].role").value("PARTICIPANT"))
+                .andExpect(jsonPath("$.data[2].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[2].memberType").value(nonMember.getMemberType().toString()))
+                .andExpect(jsonPath("$.data[2].imageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[2].state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인
+    }
+
+    @Test
+    @DisplayName("참여자 목록 반환 - state 필터 (INVITED)")
+    void getMembersOfClub_stateFiltered() throws Exception {
+        // given
+        // 테스트 클럽 생성
+        Club club = clubService.createClub(
+                Club.builder()
+                        .name("테스트 그룹")
+                        .bio("테스트 그룹 설명")
+                        .category(ClubCategory.STUDY)
+                        .mainSpot("서울")
+                        .maximumCapacity(10)
+                        .eventType(EventType.ONE_TIME)
+                        .startDate(LocalDate.of(2023, 10, 1))
+                        .endDate(LocalDate.of(2023, 10, 31))
+                        .isPublic(true)
+                        .leaderId(1L)
+                        .build()
+        );
+
+        // 추가할 멤버 (testInitData의 멤버 사용)
+        Member member1 = memberService.findById(2L).orElseThrow(
+                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
+        );
+
+        Member member2 = memberService.findById(3L).orElseThrow(
+                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
+        );
+
+        // 비회원 멤버 추가
+        Member nonMember = Member.builder()
+                .id(4L)
+                .nickname("비회원")
+                .password("password")
+                .memberType(MemberType.GUEST)
+                .tag("123456")
+                .build();
+
+        // 클럽에 멤버 추가
+        ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
+        ClubMember clubMember2 = clubMemberService.addMemberToClub(club.getId(), member2, ClubMemberRole.MANAGER);
+        ClubMember nonMemberClubMember = clubMemberService.addMemberToClub(club.getId(), nonMember, ClubMemberRole.PARTICIPANT);
+
+        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 2명 추가되었는지 확인
+
+        // 클럽 멤버의 상태 변경
+        clubMember2.updateState(ClubMemberState.JOINING); // member2를 JOINING 상태로 변경
+        clubMemberRepository.save(clubMember2); // 상태 변경된 클럽 멤버 저장
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                        get("/api/v1/clubs/" + club.getId() + "/members" + "?state=INVITED")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
+                .andExpect(handler().methodName("getMembersOfClub"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("클럽 멤버 목록을 반환합니다."))
+                .andExpect(jsonPath("$.data.length()").value(3)) // 멤버가 2명인지 확인
+
+                .andExpect(jsonPath("$.data[0].clubMemberId").value(clubMember1.getId()))
+                .andExpect(jsonPath("$.data[0].memberId").value(member1.getId()))
+                .andExpect(jsonPath("$.data[0].nickname").value(member1.getNickname()))
+                .andExpect(jsonPath("$.data[0].tag").value(member1.getTag()))
+                .andExpect(jsonPath("$.data[0].role").value("PARTICIPANT"))
+                .andExpect(jsonPath("$.data[0].email").value(member1.getEmail()))
+                .andExpect(jsonPath("$.data[0].memberType").value(member1.getMemberType().toString()))
+                .andExpect(jsonPath("$.data[0].imageUrl").value(member1.getMemberInfo().getProfileImageUrl()))
+                .andExpect(jsonPath("$.data[0].state").value(clubMember1.getState()))
+
+                .andExpect(jsonPath("$.data[1].clubMemberId").value(nonMemberClubMember.getId()))
+                .andExpect(jsonPath("$.data[1].memberId").value(nonMember.getId()))
+                .andExpect(jsonPath("$.data[1].nickname").value(nonMember.getNickname()))
+                .andExpect(jsonPath("$.data[1].tag").value(nonMember.getTag()))
+                .andExpect(jsonPath("$.data[1].role").value("PARTICIPANT"))
+                .andExpect(jsonPath("$.data[1].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[1].memberType").value(nonMember.getMemberType().toString()))
+                .andExpect(jsonPath("$.data[1].imageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data[1].state").value(nonMemberClubMember.getState())); // 비회원의 상태 확인
+
+    }
+
+    @Test
+    @DisplayName("참여자 목록 반환 - 존재하지 않는 클럽")
+    void getMembersOfClub_InvalidClubId() throws Exception {
+        // given
+        int invalidClubId = 9999; // 잘못된 클럽 ID
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                        get("/api/v1/clubs/" + invalidClubId + "/members")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
+                .andExpect(handler().methodName("getMembersOfClub"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Invalid club ID format."));
+    }
+
+    @Test
+    @DisplayName("참여자 목록 반환 - 잘못된 state 필터")
+    void getMembersOfClub_InvalidStateFilter() throws Exception {
+        // given
+        // 테스트 클럽 생성
+        Club club = clubService.createClub(
+                Club.builder()
+                        .name("테스트 그룹")
+                        .bio("테스트 그룹 설명")
+                        .category(ClubCategory.STUDY)
+                        .mainSpot("서울")
+                        .maximumCapacity(10)
+                        .eventType(EventType.ONE_TIME)
+                        .startDate(LocalDate.of(2023, 10, 1))
+                        .endDate(LocalDate.of(2023, 10, 31))
+                        .isPublic(true)
+                        .leaderId(1L)
+                        .build()
+        );
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                        get("/api/v1/clubs/" + club.getId() + "/members?state=INVALID_STATE")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
+                .andExpect(handler().methodName("getMembersOfClub"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Unknown Member state: INVALID_STATE"));
     }
 }
 


### PR DESCRIPTION
## 📢 기능 설명
- 모임 멤버 목록 조회 엔드포인트 작성
- state로 필터링 가능
- 관련 로직 작성
- 테스트 케이스 작성
- TestInitData에서 멤버 생성 시 MemberType, tag 를 포함하도록 보강
<br>

## 연결된 issue
close #35 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 클럽 멤버 목록을 조회할 수 있는 API 엔드포인트가 추가되었습니다. 상태별로 멤버를 필터링하는 기능도 지원합니다.

* **버그 수정**
  * 클럽 멤버 조회 시 존재하지 않는 클럽이나 잘못된 상태값에 대해 적절한 오류 메시지와 상태 코드가 반환됩니다.

* **테스트**
  * 클럽 멤버 목록 조회 및 상태별 필터, 예외 상황(존재하지 않는 클럽, 잘못된 상태값)에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->