### PR TITLE
[Feat] PreAuthorize 도입 - 모임 유효성 체크, 모임장 권한 체크

### DIFF
--- a/src/main/java/com/back/domain/checkList/checkList/checker/CheckListAuthorizationChecker.java
+++ b/src/main/java/com/back/domain/checkList/checkList/checker/CheckListAuthorizationChecker.java
@@ -77,7 +77,7 @@ public class CheckListAuthorizationChecker {
             throw new NoSuchElementException("일정을 찾을 수 없습니다");
         }
         // Schedule에 CheckList가 이미 존재하는 경우
-        if (schedule.getCheckList() != null) {
+        if (schedule.getCheckList() != null && !schedule.getCheckList().equals(checkList)) {
             throw new ServiceException(409, "이미 체크리스트가 존재합니다");
         }
         // Club 엔티티 반환

--- a/src/main/java/com/back/domain/checkList/checkList/checker/CheckListAuthorizationChecker.java
+++ b/src/main/java/com/back/domain/checkList/checkList/checker/CheckListAuthorizationChecker.java
@@ -1,0 +1,86 @@
+package com.back.domain.checkList.checkList.checker;
+
+import com.back.domain.checkList.checkList.entity.CheckList;
+import com.back.domain.checkList.checkList.service.CheckListService;
+import com.back.domain.club.club.checker.ClubAuthorizationChecker;
+import com.back.domain.club.club.entity.Club;
+import com.back.domain.schedule.schedule.entity.Schedule;
+import com.back.domain.schedule.schedule.service.ScheduleService;
+import com.back.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Component("checkListAuthorizationChecker")
+@RequiredArgsConstructor
+public class CheckListAuthorizationChecker {
+    private final ScheduleService scheduleService;
+    private final CheckListService checkListService;
+    private final ClubAuthorizationChecker clubChecker;
+
+    /**
+     * 체크리스트가 속한 모임의 호스트 권한이 있는지 확인
+     * @param checkListId 체크리스트 ID
+     * @param memberId 로그인 유저 ID
+     * @return 모임 호스트 권한 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isActiveClubHost(Long checkListId, Long memberId) {
+        Club club = getClubByCheckListId(checkListId);
+
+        return clubChecker.isActiveClubHost(club.getId(), memberId);
+    }
+
+    /**
+     * 체크리스트가 속한 모임의 매니저 또는 호스트 권한이 있는지 확인
+     * @param checkListId 체크리스트 ID
+     * @param memberId 로그인 유저 ID
+     * @return 모임 매니저 또는 호스트 권한 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isActiveClubManagerOrHost(Long checkListId, Long memberId) {
+        Club club = getClubByCheckListId(checkListId);
+
+        return clubChecker.isActiveClubManagerOrHost(club.getId(), memberId);
+    }
+
+    /**
+     * 체크리스트가 속한 모임의 참여자인지 확인
+     * @param checkListId 체크리스트 ID
+     * @param memberId 로그인 유저 ID
+     * @return 모임 멤버 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isClubMember(Long checkListId, Long memberId) {
+        Club club = getClubByCheckListId(checkListId);
+
+        return clubChecker.isClubMember(club.getId(), memberId);
+    }
+
+
+    // 헬퍼 메서드 -----
+
+    /**
+     * 활성화된 체크리스트의 모임 조회
+     * @param checkListId 체크리스트 ID
+     * @return 모임 엔티티
+     */
+    private Club getClubByCheckListId(Long checkListId) {
+        // 활성화된 체크리스트 조회
+        CheckList checkList = checkListService.getActiveCheckListById(checkListId);
+
+        // Schedule 엔티티 조회
+        Schedule schedule = checkList.getSchedule();
+        if (schedule == null || !schedule.isActive()) {
+            throw new NoSuchElementException("일정을 찾을 수 없습니다");
+        }
+        // Schedule에 CheckList가 이미 존재하는 경우
+        if (schedule.getCheckList() != null) {
+            throw new ServiceException(409, "이미 체크리스트가 존재합니다");
+        }
+        // Club 엔티티 반환
+        return schedule.getClub();
+    }
+}

--- a/src/main/java/com/back/domain/checkList/checkList/repository/CheckListRepository.java
+++ b/src/main/java/com/back/domain/checkList/checkList/repository/CheckListRepository.java
@@ -2,7 +2,18 @@ package com.back.domain.checkList.checkList.repository;
 
 import com.back.domain.checkList.checkList.entity.CheckList;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CheckListRepository extends JpaRepository<CheckList, Long> {
 
+    // 활성화된 체크리스트 조회
+    @Query("""
+            SELECT c FROM CheckList c
+            JOIN FETCH c.schedule
+            WHERE c.id = :checkListId
+            AND c.isActive = true
+            """)
+    Optional<CheckList> findActiveCheckListById(Long checkListId);
 }

--- a/src/main/java/com/back/domain/checkList/checkList/service/CheckListService.java
+++ b/src/main/java/com/back/domain/checkList/checkList/service/CheckListService.java
@@ -10,27 +10,21 @@ import com.back.domain.checkList.itemAssign.entity.ItemAssign;
 import com.back.domain.club.club.entity.Club;
 import com.back.domain.club.club.repository.ClubRepository;
 import com.back.domain.club.clubMember.entity.ClubMember;
-import com.back.domain.club.clubMember.repository.ClubMemberRepository;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.schedule.schedule.entity.Schedule;
 import com.back.domain.schedule.schedule.repository.ScheduleRepository;
 import com.back.global.enums.ClubMemberRole;
 import com.back.global.enums.ClubMemberState;
-import com.back.global.exception.ServiceException;
 import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import com.back.standard.util.Ut;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -336,6 +330,14 @@ public class CheckListService {
     Map<String, Object> jwtData = Ut.jwt.payload(secretKey, cleanToken);
     return RsData.of(200, "토큰 검증 성공", jwtData);
 
+  }
+
+  // 체커에 사용되는 메서드
+  public CheckList getActiveCheckListById(Long checkListId) {
+    // 활성화된 체크리스트 조회
+    return checkListRepository
+            .findActiveCheckListById(checkListId)
+            .orElseThrow(() -> new NoSuchElementException("체크리스트를 찾을 수 없습니다"));
   }
 
 }

--- a/src/main/java/com/back/domain/club/club/checker/ClubAuthorizationChecker.java
+++ b/src/main/java/com/back/domain/club/club/checker/ClubAuthorizationChecker.java
@@ -1,0 +1,162 @@
+package com.back.domain.club.club.checker;
+
+import com.back.domain.club.club.entity.Club;
+import com.back.domain.club.club.repository.ClubRepository;
+import com.back.domain.club.club.service.ClubService;
+import com.back.domain.club.clubMember.entity.ClubMember;
+import com.back.domain.club.clubMember.repository.ClubMemberRepository;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import com.back.global.enums.ClubMemberRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+@Component("clubAuthorizationChecker")
+@RequiredArgsConstructor
+public class ClubAuthorizationChecker {
+    private final MemberService memberService;
+    private final ClubRepository clubRepository;
+    private final ClubMemberRepository clubMemberRepository;
+    private final ClubService clubService;
+
+    /**
+     * 모임이 존재하는지 확인
+     * @param clubId 모임 ID
+     * @return 모임 존재 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isClubExists(Long clubId) {
+        return clubRepository.existsById(clubId);
+    }
+
+    /**
+     * 모임 호스트 권한이 있는지 확인
+     * @param clubId 모임 ID
+     * @param memberId 로그인 유저 ID
+     * @return 모임 호스트 권한 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isClubHost(Long clubId, Long memberId) {
+        Club club = getClub(clubId);
+
+        return Objects.equals(club.getLeaderId(), memberId);
+    }
+
+    /**
+     * 모임 호스트 권한이 있는지 확인 (활성화된 모임에 대해서만)
+     * @param clubId 모임 ID
+     * @param memberId 로그인 유저 ID
+     * @return 모임 호스트 권한 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isActiveClubHost(Long clubId, Long memberId) {
+        Club club = getValidAndActiveClub(clubId);
+
+        return Objects.equals(club.getLeaderId(), memberId);
+    }
+
+    /**
+     * 모임 매니저의 역할 확인 (활성화된 모임에 대해서만)
+     * @param clubId 모임 ID
+     * @param memberId 로그인 유저 ID
+     * @return 모임 매니저 권한 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isActiveClubManager(Long clubId, Long memberId) {
+        Club club = getValidAndActiveClub(clubId);
+        Member member = getMember(memberId);
+        ClubMember clubMember = getClubMember(club, member);
+
+        return clubMember.getRole() == ClubMemberRole.MANAGER;
+    }
+
+    /**
+     * 모임 호스트 또는 매니저 권한 확인 (활성화된 모임에 대해서만)
+     * @param clubId 모임 ID
+     * @param memberId 로그인 유저 ID
+     * @return 모임 호스트 또는 매니저 권한 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isActiveClubManagerOrHost(Long clubId, Long memberId) {
+        Club club = getValidAndActiveClub(clubId);
+        Member member = getMember(memberId);
+        ClubMember clubMember = getClubMember(club, member);
+
+        return clubMember.getRole() == ClubMemberRole.MANAGER
+                || Objects.equals(club.getLeaderId(), memberId);
+    }
+
+    /**
+     * 모임 참여자 여부 확인
+     * @param clubId 모임 ID
+     * @param memberId 로그인 유저 ID
+     * @return 모임 참여자 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isClubMember(Long clubId, Long memberId) {
+        Club club = getClub(clubId);
+        Member member = getMember(memberId);
+        return clubMemberRepository.existsByClubAndMember(club, member);
+    }
+
+    /**
+     * 로그인 유저가 요청한 멤버 ID와 일치하는지 확인
+     * @param targetMemberId 멤버 ID
+     * @param currentUserId 로그인 유저 ID
+     * @return 로그인 유저 - 요청한 멤버 ID 일치 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean isSelf(Long targetMemberId, Long currentUserId) {
+        return Objects.equals(targetMemberId, currentUserId);
+    }
+
+
+    // 핼퍼 메서드 ----------
+
+    /**
+     * 모임 ID로 모임 조회
+     * @param clubId 모임 ID
+     * @return 모임 엔티티
+     */
+    private Club getClub(Long clubId) {
+        return clubService.getClubById(clubId)
+                .orElseThrow(() -> new NoSuchElementException("모임이 존재하지 않습니다."));
+    }
+
+    /**
+     * 모임 ID로 활성화된 모임 조회
+     * @param clubId 모임 ID
+     * @return 활성화된 모임 엔티티
+     */
+    private Club getValidAndActiveClub(Long clubId) {
+        return clubService
+                .getValidAndActiveClub(clubId)
+                .orElseThrow(() -> new NoSuchElementException("모임이 존재하지 않거나 활성화되지 않았습니다."));
+    }
+
+    /**
+     * 멤버 ID로 멤버 조회
+     * @param memberId 멤버 ID
+     * @return 멤버 엔티티
+     */
+    private Member getMember(Long memberId) {
+        return memberService.findMemberById(memberId)
+                .orElseThrow(() -> new NoSuchElementException("멤버가 존재하지 않습니다."));
+    }
+
+    /**
+     * 클럽과 멤버로 클럽 멤버 조회
+     * @param club 모임 엔티티
+     * @param member 멤버 엔티티
+     * @return 클럽 멤버 엔티티
+     */
+    private ClubMember getClubMember(Club club, Member member) {
+        return clubMemberRepository.findByClubAndMember(club, member)
+                .orElseThrow(() -> new AccessDeniedException("권한이 없습니다."));
+    }
+}

--- a/src/main/java/com/back/domain/club/club/repository/ClubRepository.java
+++ b/src/main/java/com/back/domain/club/club/repository/ClubRepository.java
@@ -18,6 +18,8 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
 
     Page<Club> findAllByIsPublicTrue(Pageable pageable);
 
+    Optional<Club> findByIdAndStateIsTrue(Long clubId);
+
     @Query("""
             SELECT c FROM Club c 
             WHERE c.id = :clubId 

--- a/src/main/java/com/back/domain/club/club/repository/ClubRepository.java
+++ b/src/main/java/com/back/domain/club/club/repository/ClubRepository.java
@@ -4,6 +4,8 @@ import com.back.domain.club.club.entity.Club;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -15,4 +17,14 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
     Optional<Club> findFirstByOrderByIdDesc();
 
     Page<Club> findAllByIsPublicTrue(Pageable pageable);
+
+    @Query("""
+            SELECT c FROM Club c 
+            WHERE c.id = :clubId 
+            AND c.state = TRUE 
+            AND c.endDate >= CURRENT_DATE
+            """)
+    Optional<Club> findValidAndActiveClub(
+            @Param("clubId") Long clubId
+    );
 }

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -68,6 +68,10 @@ public class ClubService {
         return clubRepository.findById(clubId);
     }
 
+    public Optional<Club> getValidAndActiveClub(Long clubId) {
+        return clubRepository.findValidAndActiveClub(clubId);
+    }
+
     /**
      * 클럽을 생성합니다. (테스트용. controller에서 사용하지 않음)
      * @param club 클럽 정보

--- a/src/main/java/com/back/domain/schedule/schedule/checker/ScheduleAuthorizationChecker.java
+++ b/src/main/java/com/back/domain/schedule/schedule/checker/ScheduleAuthorizationChecker.java
@@ -13,6 +13,12 @@ public class ScheduleAuthorizationChecker {
     private final ScheduleService scheduleService;
     private final ClubAuthorizationChecker clubChecker;
 
+    /**
+     * 모임의 활성화된 스케줄에 대해 로그인한 유저가 모임 호스트인지 확인
+     * @param scheduleId
+     * @param memberId
+     * @return 모임 호스트 여부
+     */
     @Transactional(readOnly = true)
     public boolean isActiveClubHost(Long scheduleId, Long memberId) {
         Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
@@ -21,6 +27,12 @@ public class ScheduleAuthorizationChecker {
         return clubChecker.isActiveClubHost(clubId, memberId);
     }
 
+    /**
+     * 모임의 활성화된 스케줄에 대해 로그인한 유저가 모임 관리자 또는 호스트인지 확인
+     * @param scheduleId
+     * @param memberId
+     * @return 모임 관리자 또는 호스트 여부
+     */
     @Transactional(readOnly = true)
     public boolean isActiveClubManagerOrHost(Long scheduleId, Long memberId) {
         Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
@@ -29,6 +41,12 @@ public class ScheduleAuthorizationChecker {
         return clubChecker.isActiveClubManagerOrHost(clubId, memberId);
     }
 
+    /**
+     * 모임의 활성화된 스케줄에 대해 로그인한 유저가 모임 멤버인지 확인
+     * @param scheduleId
+     * @param memberId
+     * @return 모임 멤버 여부
+     */
     @Transactional(readOnly = true)
     public boolean isClubMember(Long scheduleId, Long memberId) {
         Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);

--- a/src/main/java/com/back/domain/schedule/schedule/checker/ScheduleAuthorizationChecker.java
+++ b/src/main/java/com/back/domain/schedule/schedule/checker/ScheduleAuthorizationChecker.java
@@ -1,0 +1,39 @@
+package com.back.domain.schedule.schedule.checker;
+
+import com.back.domain.club.club.checker.ClubAuthorizationChecker;
+import com.back.domain.schedule.schedule.entity.Schedule;
+import com.back.domain.schedule.schedule.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component("scheduleAuthorizationChecker")
+@RequiredArgsConstructor
+public class ScheduleAuthorizationChecker {
+    private final ScheduleService scheduleService;
+    private final ClubAuthorizationChecker clubChecker;
+
+    @Transactional(readOnly = true)
+    public boolean isActiveClubHost(Long scheduleId, Long memberId) {
+        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Long clubId = schedule.getClub().getId();
+
+        return clubChecker.isActiveClubHost(clubId, memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isActiveClubManagerOrHost(Long scheduleId, Long memberId) {
+        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Long clubId = schedule.getClub().getId();
+
+        return clubChecker.isActiveClubManagerOrHost(clubId, memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isClubMember(Long scheduleId, Long memberId) {
+        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Long clubId = schedule.getClub().getId();
+
+        return clubChecker.isClubMember(clubId, memberId);
+    }
+}

--- a/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
@@ -43,6 +43,14 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("endDateTime") LocalDateTime endDateTime
     );
 
+    // 활성화된 일정 ID로 조회
+    @Query("""
+            SELECT s FROM Schedule s
+            JOIN FETCH s.club
+            WHERE s.id = :scheduleId 
+            AND s.isActive = true
+            """)
+    Optional<Schedule> findActiveScheduleById(Long scheduleId);
 
     // 특정 모임의 최신 일정을 ID 기준으로 내림차순 정렬하여 조회
     Optional<Schedule> findFirstByClubIdOrderByIdDesc(Long clubId);

--- a/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
+++ b/src/main/java/com/back/domain/schedule/schedule/service/ScheduleService.java
@@ -75,7 +75,19 @@ public class ScheduleService {
                 .findById(scheduleId)
                 .orElseThrow(() -> new NoSuchElementException("%d번 일정은 존재하지 않습니다.".formatted(scheduleId)));
     }
-    
+
+    /**
+     * 활성화된 일정 조회
+     * @param scheduleId
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public Schedule getActiveScheduleById(Long scheduleId) {
+        return scheduleRepository
+                .findActiveScheduleById(scheduleId)
+                .orElseThrow(() -> new NoSuchElementException("%d번 일정은 존재하지 않습니다.".formatted(scheduleId)));
+    }
+
     /**
      * 특정 모임의 최신 일정 조회
      * @param clubId
@@ -88,6 +100,11 @@ public class ScheduleService {
                 .orElseThrow(() -> new NoSuchElementException("%d번 모임의 일정은 존재하지 않습니다.".formatted(clubId)));
     }
 
+    /**
+     * 특정 모임의 일정 개수 조회
+     * @param clubId
+     * @return
+     */
     @Transactional(readOnly = true)
     public long countClubSchedules(Long clubId) {
         return scheduleRepository.countByClubId(clubId);

--- a/src/main/java/com/back/global/security/MockAuthFilterForSpecificApi.java
+++ b/src/main/java/com/back/global/security/MockAuthFilterForSpecificApi.java
@@ -1,0 +1,59 @@
+package com.back.global.security;
+
+import com.back.global.enums.MemberType;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@Order(1)
+public class MockAuthFilterForSpecificApi extends OncePerRequestFilter {
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        // 특정 API 경로에만 필터 적용
+        return !request.getRequestURI().startsWith("/api/v1/schedules");
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 이미 인증 정보가 있으면 패스
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            // 테스트용 SecurityUser 생성
+            SecurityUser testUser = new SecurityUser(
+                    1L,
+                    "홍길동",
+                    "fakeTag",
+                    MemberType.MEMBER,
+                    "password1",
+                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            );
+            Authentication auth = new UsernamePasswordAuthenticationToken(
+                    testUser,
+                    null,
+                    testUser.getAuthorities()
+            );
+
+            SecurityContextHolder
+                    .getContext()
+                    .setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/back/global/security/MockAuthFilterForSpecificApi.java
+++ b/src/main/java/com/back/global/security/MockAuthFilterForSpecificApi.java
@@ -5,6 +5,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -17,6 +18,7 @@ import java.io.IOException;
 import java.util.List;
 
 @Component
+@Profile("test") // 테스트 프로파일에서만 활성화
 @Order(1)
 public class MockAuthFilterForSpecificApi extends OncePerRequestFilter {
     @Override

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -5,14 +5,14 @@ import com.back.standard.util.Ut;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     //private final CustomAuthenticationFilter customAuthenticationFilter;

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -10,12 +10,14 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     //private final CustomAuthenticationFilter customAuthenticationFilter;
+    private final MockAuthFilterForSpecificApi mockAuthFilterForSpecificApi;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -31,6 +33,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(AbstractHttpConfigurer::disable)
                 //.addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(mockAuthFilterForSpecificApi, UsernamePasswordAuthenticationFilter.class)
                 .headers(
                         headers -> headers
                                 .frameOptions(


### PR DESCRIPTION
## 📢 기능 설명
- 모임, 모임 참여자 관련 인가 추가
  - 모임 유효한지 (활성화 상태, 종료일이 서버일 이후인지)
  - 모임장 권한 (CRUD)
  - 모임 매니저 권한 (활성화된 모임만 - U)
  - 모임장 또는 모임 매니저 권한
  - 모임 참여자 권한 (모임 - R)


- 일정 관련 인가 추가
  - 일정 유효 체크 + 모임장 권한
  - 일정 유효 체크 + 모임장 또는 모임 매니저 권한
  - 일정 유효 체크 + 모임 참여자 권한


- 체크리스트 관련 인가 추가 
  - 체크리스트, 일정 유효 체크 + 모임장 권한
  - 체크리스트, 일정 유효 체크 + 모임장 또는 모임 매니저 권한
  - 체크리스트, 일정 유효 체크 + 모임 참여자 권한


- 페이크 로그인 유저(일정 API만)

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #131 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 클럽, 일정, 체크리스트에 대한 역할 및 멤버십 권한 확인 기능이 추가되었습니다.
  * 특정 API 요청에 대해 모의 인증 사용자를 자동으로 적용하는 보안 필터가 도입되었습니다.

* **기타**
  * 메서드 단위 보안이 활성화되었습니다.
  * 일부 서비스 및 저장소에 활성화된 클럽, 일정, 체크리스트 조회 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->