### PR TITLE
[fix] MockAuthFilterForSpecificApi 테스트 일때만 필터 적용

### DIFF
--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -12,12 +12,14 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import java.util.Optional;
+
 @Configuration
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     //private final CustomAuthenticationFilter customAuthenticationFilter;
-    private final MockAuthFilterForSpecificApi mockAuthFilterForSpecificApi;
+    private final Optional<MockAuthFilterForSpecificApi> mockAuthFilterForSpecificApi;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -33,7 +35,6 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(AbstractHttpConfigurer::disable)
                 //.addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(mockAuthFilterForSpecificApi, UsernamePasswordAuthenticationFilter.class)
                 .headers(
                         headers -> headers
                                 .frameOptions(
@@ -74,6 +75,11 @@ public class SecurityConfig {
                                         }
                                 )
                 );
+
+        // Profile test 일때 Mock 인증 필터를 특정 API에만 적용
+        mockAuthFilterForSpecificApi.ifPresent(filter ->
+                http.addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
+        );
 
         return http.build();
 


### PR DESCRIPTION
## 📢 기능 설명
MockAuthFilterForSpecificApi에 @Profile("test") 이라고 지정해 놓고 filterChain에서 항상 걸고 있어 
서버 실행 시 빈 찾지 못하는 오류 발생
-> Optinal로 받아서 빈 있을 때만 필터 적용으로 해결

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #147 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 특정 API에 대한 인증 필터가 있을 때만 조건적으로 적용되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->