### PR TITLE
 [fix] 멤버 초대 시 상태에 따른 예외 처리

### DIFF
--- a/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
@@ -24,6 +24,28 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<String> findExistingEmails(@Param("clubId") Long clubId,
                                     @Param("emails") List<String> emails);
 
+    @Query("""
+    SELECT cm.member.memberInfo.email
+    FROM ClubMember cm
+    WHERE cm.club.id = :clubId
+      AND cm.member.memberInfo.email IN :emails
+      AND cm.state != 'WITHDRAWN'
+""")
+    List<String> findExistingEmailsExcludingWithdraws(@Param("clubId") Long clubId,
+                                    @Param("emails") List<String> emails);
+
+    @Query("""
+    SELECT cm.member.memberInfo.email
+    FROM ClubMember cm
+    WHERE cm.club.id = :clubId
+      AND cm.member.memberInfo.email IN :emails
+      AND cm.state = 'WITHDRAWN'
+""")
+    List<String> findWithdrawnEmails(@Param("clubId") Long clubId,
+                                                      @Param("emails") List<String> emails);
+
+
+
     Optional<ClubMember> findByClubAndMember(Club club, Member member);
 
     List<ClubMember> findByClubAndState(Club club, ClubMemberState clubMemberState);

--- a/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
@@ -15,35 +15,6 @@ import java.util.Optional;
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<ClubMember> findAllByClubId(Long clubId);
 
-    @Query("""
-    SELECT cm.member.memberInfo.email
-    FROM ClubMember cm
-    WHERE cm.club.id = :clubId
-      AND cm.member.memberInfo.email IN :emails
-""")
-    List<String> findExistingEmails(@Param("clubId") Long clubId,
-                                    @Param("emails") List<String> emails);
-
-    @Query("""
-    SELECT cm.member.memberInfo.email
-    FROM ClubMember cm
-    WHERE cm.club.id = :clubId
-      AND cm.member.memberInfo.email IN :emails
-      AND cm.state != 'WITHDRAWN'
-""")
-    List<String> findExistingEmailsExcludingWithdraws(@Param("clubId") Long clubId,
-                                    @Param("emails") List<String> emails);
-
-    @Query("""
-    SELECT cm.member.memberInfo.email
-    FROM ClubMember cm
-    WHERE cm.club.id = :clubId
-      AND cm.member.memberInfo.email IN :emails
-      AND cm.state = 'WITHDRAWN'
-""")
-    List<String> findWithdrawnEmails(@Param("clubId") Long clubId,
-                                                      @Param("emails") List<String> emails);
-
     // 요청 이메일 목록에 해당하는 ClubMember 정보를 한 번에 조회
     @Query("""
        SELECT cm

--- a/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
@@ -44,6 +44,24 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<String> findWithdrawnEmails(@Param("clubId") Long clubId,
                                                       @Param("emails") List<String> emails);
 
+    // 요청 이메일 목록에 해당하는 ClubMember 정보를 한 번에 조회
+    @Query("""
+       SELECT cm
+       FROM ClubMember cm
+       WHERE cm.club.id = :clubId
+              AND cm.member.memberInfo.email
+              IN :emails
+    """)
+    List<ClubMember> findClubMembersByClubIdAndEmails(@Param("clubId") Long clubId, @Param("emails") List<String> emails);
+
+    //정원 체크를 위한 현재 활동 멤버 수 조회 (탈퇴 제외)
+    @Query("""
+    SELECT COUNT(cm)
+    FROM ClubMember cm
+    WHERE cm.club.id = :clubId
+        AND cm.state != 'WITHDRAWN'
+    """)
+    long countActiveMembersByClubId(@Param("clubId") Long clubId);
 
 
     Optional<ClubMember> findByClubAndMember(Club club, Member member);

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -18,10 +18,11 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -63,60 +64,67 @@ public class ClubMemberService {
      */
     @Transactional
     public void addMembersToClub(Long clubId, ClubMemberDtos.ClubMemberRegisterRequest reqBody) {
-        Club club = clubService.getClubById(clubId).orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
+        Club club = clubService.getClubById(clubId)
+                .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
 
-        // 권한 확인 : 현재 로그인한 유저가 클럽 호스트인지 확인
+        // 권한 확인
         clubService.validateHostPermission(clubId);
 
-        // 요청된 이메일 추출
-        List<String> requestEmails = reqBody.members().stream()
-                .map(ClubMemberDtos.ClubMemberRegisterInfo::email)
-                .toList();
+        // 1. 요청 데이터에서 이메일 기준 중복 제거 (나중에 들어온 정보가 우선)
+        Map<String, ClubMemberDtos.ClubMemberRegisterInfo> uniqueMemberInfoByEmail = reqBody.members().stream()
+                .collect(Collectors.toMap(
+                        ClubMemberDtos.ClubMemberRegisterInfo::email,
+                        info -> info,
+                        (existing, replacement) -> replacement // 키가 중복될 경우, 기존 값(existing)을 새로운 값(replacement)으로 덮어씀
+                ));
 
-        // 이미 가입된 멤버 이메일 목록을 조회 (IN 쿼리)
-        Set<String> existingEmails = new HashSet<>(
-                clubMemberRepository.findExistingEmails(clubId, requestEmails)
-        );
+        // 2. 요청된 이메일 목록을 한 번에 조회하여 Map으로 변환 (효율적인 탐색을 위해)
+        List<String> requestEmails = new ArrayList<>(uniqueMemberInfoByEmail.keySet());
+        Map<String, ClubMember> existingMembersByEmail = clubMemberRepository.findClubMembersByClubIdAndEmails(clubId, requestEmails)
+                .stream()
+                .collect(Collectors.toMap(cm -> cm.getMember().getMemberInfo().getEmail(), cm -> cm));
 
-        // 1. 실제로 추가될 새로운 멤버 목록을 먼저 필터링합니다.
-        List<ClubMemberDtos.ClubMemberRegisterInfo> newMembersToAdd = reqBody.members().stream()
-                .distinct()
-                .filter(memberInfo -> !existingEmails.contains(memberInfo.email()))
-                .toList();
+        // 3. 신규 추가/상태 변경할 멤버 목록 준비
+        List<ClubMember> membersToSave = new ArrayList<>();
+        List<ClubMemberDtos.ClubMemberRegisterInfo> newMemberRequests = new ArrayList<>();
 
-        // 2. 멤버를 추가하기 전에 정원 초과 여부를 먼저 확인합니다.
-        if (club.getClubMembers().size() + newMembersToAdd.size() > club.getMaximumCapacity()) {
+        uniqueMemberInfoByEmail.values().forEach(memberInfo -> {
+            ClubMember existingMember = existingMembersByEmail.get(memberInfo.email());
+
+            if (existingMember != null) {
+                if (existingMember.getState() == ClubMemberState.WITHDRAWN) {
+                    existingMember.updateState(ClubMemberState.INVITED);
+                    // 요청된 역할로 업데이트
+                    existingMember.updateRole(ClubMemberRole.fromString(memberInfo.role().toUpperCase()));
+                    membersToSave.add(existingMember);
+                }
+            } else {
+                newMemberRequests.add(memberInfo);
+            }
+        });
+
+        // 4. 정원 초과 여부 검사 (효율적인 COUNT 쿼리 사용)
+        long currentActiveMembers = clubMemberRepository.countActiveMembersByClubId(clubId);
+        if (currentActiveMembers + newMemberRequests.size() > club.getMaximumCapacity()) {
             throw new ServiceException(400, "클럽의 최대 멤버 수를 초과했습니다.");
         }
 
-        // 3. 유효성 검사를 통과한 경우에만 멤버를 추가합니다.
-        newMembersToAdd.forEach(memberInfo -> {
+        // 5. 새로운 멤버 엔티티 생성
+        for (ClubMemberDtos.ClubMemberRegisterInfo memberInfo : newMemberRequests) {
             Member member = memberService.findMemberByEmail(memberInfo.email());
-
-            ClubMember clubMember = ClubMember.builder()
+            ClubMember newClubMember = ClubMember.builder()
                     .member(member)
                     .role(ClubMemberRole.fromString(memberInfo.role().toUpperCase()))
                     .state(ClubMemberState.INVITED)
                     .build();
-
-            club.addClubMember(clubMember);
-            clubMemberRepository.save(clubMember);
-        });
-
-        // 4. 탈퇴한 멤버 이메일 목록을 조회합니다.
-        List<String> withdrawnEmails = clubMemberRepository.findWithdrawnEmails(clubId, requestEmails);
-
-        // 5. 탈퇴한 멤버 이메일이 있다면, 해당 멤버를 클럽에 다시 추가합니다.
-        if (!withdrawnEmails.isEmpty()) {
-            List<ClubMember> withdrawnMembers = clubMemberRepository.findByClubAndState(club, ClubMemberState.WITHDRAWN);
-            for (ClubMember withdrawnMember : withdrawnMembers) {
-                if (withdrawnEmails.contains(withdrawnMember.getMember().getMemberInfo().getEmail())) {
-                    withdrawnMember.updateState(ClubMemberState.INVITED);
-                    clubMemberRepository.save(withdrawnMember);
-                }
-            }
+            club.addClubMember(newClubMember); // 양방향 연관관계 설정
+            membersToSave.add(newClubMember);
         }
 
+        // 6. 변경/추가된 모든 멤버 정보를 한 번에 저장 (Batch Insert/Update)
+        if (!membersToSave.isEmpty()) {
+            clubMemberRepository.saveAll(membersToSave);
+        }
     }
 
     /**

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -215,7 +215,7 @@ class ApiV1ClubMemberControllerTest {
         assertThat(club.getClubMembers().get(0).getMember().getEmail()).isEqualTo(hostMember.getEmail());
         assertThat(club.getClubMembers().get(0).getRole()).isEqualTo(ClubMemberRole.HOST);
         assertThat(club.getClubMembers().get(1).getMember().getEmail()).isEqualTo(member1.getEmail());
-        assertThat(club.getClubMembers().get(1).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT); // 가장 먼저 추가된 역할이 유지됨
+        assertThat(club.getClubMembers().get(1).getRole()).isEqualTo(ClubMemberRole.MANAGER); // 나중에 추가한 역할이 유지됨
     }
 
     @Test


### PR DESCRIPTION
## 📢 기능 설명
- 멤버 추가 시 예외 처리 로직 추가
- 기존에 `초대됨`, `가입 신청`, `가입 중` 상태인 유저는 포함되지 않음
- `탈퇴` 상태인 유저는 `초대됨`으로 상태 변경
- 관련 로직도 효율적으로 리팩토링
<br>

## 연결된 issue
close #145 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 클럽 멤버 이메일 및 상태별 조회, 클럽 내 활성 멤버 수 집계 등 다양한 멤버 관련 조회 기능이 추가되었습니다.

* **버그 수정**
  * 클럽에 중복된 이메일로 멤버를 추가할 때, 마지막에 입력된 역할이 적용되도록 동작이 변경되었습니다.

* **리팩터링**
  * 멤버 추가 시 탈퇴 멤버의 재초대 및 역할 갱신, 일괄 저장 등 처리 효율성과 일관성이 개선되었습니다.

* **테스트**
  * 중복 멤버 추가 시 역할 적용 관련 테스트가 최신 동작에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->