### PR TITLE
 [feat] 모임 가입 신청 수락

### DIFF
--- a/src/main/java/com/back/domain/club/club/entity/Club.java
+++ b/src/main/java/com/back/domain/club/club/entity/Club.java
@@ -169,5 +169,10 @@ public class Club {
         this.isPublic = isPublic;
     }
 
+    public void removeClubMember(ClubMember clubMember) {
+      this.clubMembers.remove(clubMember);
+      clubMember.setClub(null); // 양방향 연관관계 해제
+    }
+
 
 }

--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -65,4 +65,26 @@ public class ApiV1ClubMemberController {
         return RsData.of(200, "클럽 멤버 목록이 조회됐습니다.", clubMemberResponse);
     }
 
+    @PatchMapping("/{memberId}/approval")
+    @Operation(summary = "클럽 가입 신청 승인")
+    public RsData<Void> approveMemberApplication(
+            @PathVariable Long clubId,
+            @PathVariable Long memberId
+    ) {
+        clubMemberService.handleMemberApplication(clubId, memberId, true);
+
+        return RsData.of(200, "가입 신청이 승인됐습니다.", null);
+    }
+
+    @DeleteMapping("/{memberId}/approval")
+    @Operation(summary = "클럽 가입 신청 거절")
+    public RsData<Void> rejectMemberApplication(
+            @PathVariable Long clubId,
+            @PathVariable Long memberId
+    ) {
+        clubMemberService.handleMemberApplication(clubId, memberId, false);
+
+        return RsData.of(200, "가입 신청이 거절됐습니다.", null);
+    }
+
 }

--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -64,4 +64,5 @@ public class ApiV1ClubMemberController {
 
         return RsData.of(200, "클럽 멤버 목록이 조회됐습니다.", clubMemberResponse);
     }
+
 }

--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1MyClubController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1MyClubController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class ApiV1MyClubController {
     private final MyClubService myClubService;
 
-    @PostMapping("{clubId}/join")
+    @PatchMapping("{clubId}/join")
     @Operation(summary = "클럽 초대 수락")
     public RsData<MyClubControllerDtos.SimpleClubInfo> acceptClubInvitation(
             @PathVariable Long clubId

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -267,4 +267,42 @@ public class ClubMemberService {
     public boolean existsByClubAndMember(Club club, Member member) {
         return clubMemberRepository.existsByClubAndMember(club, member);
     }
+
+    /**
+     * 클럽 가입 신청을 승인하거나 거절합니다.
+     * @param clubId 클럽 ID
+     * @param memberId 멤버 ID
+     * @param approve true면 승인, false면 거절
+     */
+    public void handleMemberApplication(Long clubId, Long memberId, boolean approve) {
+        // 권한 확인 : 현재 로그인한 유저가 클럽 호스트인지 확인
+        clubService.validateHostPermission(clubId);
+
+        Club club = clubService.getClubById(clubId)
+                .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
+        Member member = memberService.findMemberById(memberId)
+                .orElseThrow(() -> new ServiceException(404, "멤버가 존재하지 않습니다."));
+        ClubMember clubMember = clubMemberRepository.findByClubAndMember(club, member)
+                .orElseThrow(() -> new ServiceException(400, "가입 신청 상태가 아닙니다."));
+
+        // 현재 상태가 APPLYING이 아닌 경우 예외 처리
+        if (clubMember.getState() != ClubMemberState.APPLYING) {
+            if(clubMember.getState() == ClubMemberState.JOINING)
+                throw new ServiceException(400, "이미 가입 상태입니다.");
+            else
+                throw new ServiceException(400, "가입 신청 상태가 아닙니다.");
+        }
+
+        // 승인 또는 거절 처리
+        if (approve) {
+            clubMember.updateState(ClubMemberState.JOINING);
+            clubMemberRepository.save(clubMember);
+        } else {
+            clubMemberRepository.delete(clubMember);
+            // 거절 시 클럽에서 멤버 제거
+            club.removeClubMember(clubMember);
+        }
+
+
+    }
 }

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -274,6 +274,7 @@ public class ClubMemberService {
      * @param memberId 멤버 ID
      * @param approve true면 승인, false면 거절
      */
+    @Transactional
     public void handleMemberApplication(Long clubId, Long memberId, boolean approve) {
         // 권한 확인 : 현재 로그인한 유저가 클럽 호스트인지 확인
         clubService.validateHostPermission(clubId);

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -1518,7 +1518,7 @@ class ApiV1ClubMemberControllerTest {
     @Test
     @DisplayName("가입 신청 수락")
     @WithUserDetails(value = "hgd222@test.com") // 1번 멤버로 로그인
-    void acceptJoinRequest() throws Exception {
+    void approveMemberApplication() throws Exception {
         // given
         // 테스트 클럽 생성
         Club club = clubService.createClub(
@@ -1567,10 +1567,10 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("acceptJoinRequest"))
+                .andExpect(handler().methodName("approveMemberApplication"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("가입 신청이 수락되었습니다."));
+                .andExpect(jsonPath("$.message").value("가입 신청이 승인됐습니다."));
 
         // 클럽 멤버의 상태가 JOINING으로 변경되었는지 확인
         ClubMember updatedClubMember = clubMemberRepository.findById(clubMember1.getId())
@@ -1581,7 +1581,7 @@ class ApiV1ClubMemberControllerTest {
     @Test
     @DisplayName("가입 신청 수락 - 신청하지 않은 멤버")
     @WithUserDetails(value = "hgd222@test.com") // 1번 멤버로 로그인
-    void acceptJoinRequest_NotAppliedMember() throws Exception {
+    void approveMemberApplication_NotAppliedMember() throws Exception {
         // given
         // 테스트 클럽 생성
         Club club = clubService.createClub(
@@ -1625,7 +1625,7 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("acceptJoinRequest"))
+                .andExpect(handler().methodName("approveMemberApplication"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("가입 신청 상태가 아닙니다."));
@@ -1634,7 +1634,7 @@ class ApiV1ClubMemberControllerTest {
     @Test
     @DisplayName("가입 신청 수락 - 이미 가입 상태인 멤버")
     @WithUserDetails(value = "hgd222@test.com") // 1번 멤버로 로그인
-    void acceptJoinRequest_AlreadyJoinedMember() throws Exception {
+    void approveMemberApplication_AlreadyJoinedMember() throws Exception {
         // given
         // 테스트 클럽 생성
         Club club = clubService.createClub(
@@ -1683,7 +1683,7 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("acceptJoinRequest"))
+                .andExpect(handler().methodName("approveMemberApplication"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("이미 가입 상태입니다."));
@@ -1692,7 +1692,7 @@ class ApiV1ClubMemberControllerTest {
     @Test
     @DisplayName("가입 신청 수락 - 탈퇴 상태인 멤버")
     @WithUserDetails(value = "hgd222@test.com") // 1번 멤버로 로그인
-    void acceptJoinRequest_WithdrawnMember() throws Exception {
+    void approveMemberApplication_WithdrawnMember() throws Exception {
         // given
         // 테스트 클럽 생성
         Club club = clubService.createClub(
@@ -1741,7 +1741,7 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("acceptJoinRequest"))
+                .andExpect(handler().methodName("approveMemberApplication"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("가입 신청 상태가 아닙니다."));
@@ -1750,7 +1750,7 @@ class ApiV1ClubMemberControllerTest {
     @Test
     @DisplayName("가입 신청 수락 - 초대됨 상태인 멤버")
     @WithUserDetails(value = "hgd222@test.com") // 1번 멤버로 로그인
-    void acceptJoinRequest_InvitedMember() throws Exception {
+    void approveMemberApplication_InvitedMember() throws Exception {
         // given
         // 테스트 클럽 생성
         Club club = clubService.createClub(
@@ -1799,7 +1799,7 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("acceptJoinRequest"))
+                .andExpect(handler().methodName("approveMemberApplication"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("가입 신청 상태가 아닙니다."));
@@ -1808,7 +1808,7 @@ class ApiV1ClubMemberControllerTest {
     @Test
     @DisplayName("가입 신청 수락 - 권한 없는 멤버")
     @WithUserDetails(value = "hgd222@test.com") // 1번 멤버로 로그인
-    void acceptJoinRequest_UnauthorizedMember() throws Exception {
+    void approveMemberApplication_UnauthorizedMember() throws Exception {
         // given
         // 테스트 클럽 생성
         Club club = clubService.createClub(
@@ -1835,6 +1835,16 @@ class ApiV1ClubMemberControllerTest {
                 ClubMemberRole.HOST
         );
 
+        // 클럽에 호스트가 아닌 멤버 추가
+        Member nonHostMember = memberService.findMemberById(1L).orElseThrow(
+                () -> new IllegalStateException("호스트가 아닌 멤버가 존재하지 않습니다.")
+        );
+        clubMemberService.addMemberToClub(
+                club.getId(),
+                nonHostMember,
+                ClubMemberRole.PARTICIPANT
+        );
+
         // 추가할 멤버 (testInitData의 멤버 사용)
         Member member1 = memberService.findMemberById(3L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
@@ -1845,7 +1855,7 @@ class ApiV1ClubMemberControllerTest {
         clubMember1.updateState(ClubMemberState.APPLYING); // 가입 신청 상태로 변경
         clubMemberRepository.save(clubMember1); // 상태 변경된 클럽 멤버 저장
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 2명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 2명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1857,16 +1867,16 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("acceptJoinRequest"))
+                .andExpect(handler().methodName("approveMemberApplication"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value(403))
-                .andExpect(jsonPath("$.message").value("권한이 없습니다. 클럽 호스트만 가입 신청을 수락할 수 있습니다."));
+                .andExpect(jsonPath("$.message").value("권한이 없습니다."));
     }
 
     @Test
     @DisplayName("가입 신청 수락 - 클럽이 존재하지 않는 경우")
     @WithUserDetails(value = "hgd222@test.com") // 1번 멤버로 로그인
-    void acceptJoinRequest_ClubNotFound() throws Exception {
+    void approveMemberApplication_ClubNotFound() throws Exception {
         // given
         long invalidClubId = 9999L; // 존재하지 않는 클럽 ID
 
@@ -1885,7 +1895,7 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("acceptJoinRequest"))
+                .andExpect(handler().methodName("approveMemberApplication"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
                 .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
@@ -1936,7 +1946,7 @@ class ApiV1ClubMemberControllerTest {
 
         // when
         ResultActions resultActions = mvc.perform(
-                        patch("/api/v1/clubs/" + club.getId() + "/members/" + member1.getId() + "/rejection")
+                    delete("/api/v1/clubs/" + club.getId() + "/members/" + member1.getId() + "/approval")
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
@@ -1944,10 +1954,10 @@ class ApiV1ClubMemberControllerTest {
         // then
         resultActions
                 .andExpect(handler().handlerType(ApiV1ClubMemberController.class))
-                .andExpect(handler().methodName("rejectJoinRequest"))
+                .andExpect(handler().methodName("rejectMemberApplication"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("가입 신청이 거절되었습니다."));
+                .andExpect(jsonPath("$.message").value("가입 신청이 거절됐습니다."));
 
         // 클럽 멤버가 삭제됐는지 확인
         assertThat(club.getClubMembers().size()).isEqualTo(1); // 클럽에 멤버가 1명(호스트) 남아있는지 확인

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -1514,5 +1514,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(jsonPath("$.data.members[0].profileImageUrl").value("")) // 호스트는 이미지 URL이 없으므로 빈 문자열
                 .andExpect(jsonPath("$.data.members[0].state").value(club.getClubMembers().get(0).getState().name())); // 호스트의 상태 확인
     }
+
+
 }
 

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1MyClubControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1MyClubControllerTest.java
@@ -27,8 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -92,7 +91,7 @@ class ApiV1MyClubControllerTest {
 
         // when
         ResultActions resultActions = mvc.perform(
-                        post("/api/v1/my-clubs/" + club.getId() + "/join")
+                        patch("/api/v1/my-clubs/" + club.getId() + "/join")
                 )
                 .andDo(print());
 
@@ -205,7 +204,7 @@ class ApiV1MyClubControllerTest {
 
         // when
         ResultActions resultActions = mvc.perform(
-                        post("/api/v1/my-clubs/" + club.getId() + "/join")
+                        patch("/api/v1/my-clubs/" + club.getId() + "/join")
                 )
                 .andDo(print());
 
@@ -261,7 +260,7 @@ class ApiV1MyClubControllerTest {
 
         // when
         ResultActions resultActions = mvc.perform(
-                        post("/api/v1/my-clubs/" + club.getId() + "/join")
+                        patch("/api/v1/my-clubs/" + club.getId() + "/join")
                 )
                 .andDo(print());
 
@@ -319,7 +318,7 @@ class ApiV1MyClubControllerTest {
 
         // when
         ResultActions resultActions = mvc.perform(
-                        post("/api/v1/my-clubs/" + club.getId() + "/join")
+                        patch("/api/v1/my-clubs/" + club.getId() + "/join")
                 )
                 .andDo(print());
 
@@ -339,7 +338,7 @@ class ApiV1MyClubControllerTest {
     public void acceptClubInvitation_InvalidClubId() throws Exception {
         // when
         ResultActions resultActions = mvc.perform(
-                        post("/api/v1/my-clubs/999/join") // 존재하지 않는 클럽 ID
+                        patch("/api/v1/my-clubs/999/join") // 존재하지 않는 클럽 ID
                 )
                 .andDo(print());
 


### PR DESCRIPTION
## 📢 기능 설명
- 모임 가입 신청 수락/거절 엔드포인트 작성
- 관련 로직 작성
- 관련 테스트 케이스 작성
- 모임 초대 수락 엔드포인트의 메서드를 `POST` -> `PATCH`로 변경 (일관성 유지)
<br>

## 연결된 issue
close #129 
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 클럽 멤버 신청 승인 및 거절을 위한 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 클럽 초대 수락 엔드포인트의 HTTP 메서드가 POST에서 PATCH로 변경되었습니다.

* **테스트**
  * 클럽 멤버 신청 승인/거절 및 관련 예외 상황에 대한 테스트가 추가되었습니다.
  * 클럽 초대 수락 관련 테스트에서 HTTP 메서드가 PATCH로 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->