### PR TITLE
[refactor] 가입된 모임 참여자만 권한

### DIFF
--- a/src/main/java/com/back/domain/club/club/checker/ClubAuthorizationChecker.java
+++ b/src/main/java/com/back/domain/club/club/checker/ClubAuthorizationChecker.java
@@ -46,7 +46,7 @@ public class ClubAuthorizationChecker {
     }
 
     /**
-     * 모임 호스트 권한이 있는지 확인 (활성화된 모임에 대해서만)
+     * 모임 호스트 권한이 있는지 확인 (종료 안된 활성화된 모임에 대해서만)
      * @param clubId 모임 ID
      * @param memberId 로그인 유저 ID
      * @return 모임 호스트 권한 여부
@@ -59,7 +59,7 @@ public class ClubAuthorizationChecker {
     }
 
     /**
-     * 모임 매니저의 역할 확인 (활성화된 모임에 대해서만)
+     * 모임 매니저의 역할 확인 (종료 안된 활성화된 모임에 대해서만)
      * @param clubId 모임 ID
      * @param memberId 로그인 유저 ID
      * @return 모임 매니저 권한 여부
@@ -74,7 +74,7 @@ public class ClubAuthorizationChecker {
     }
 
     /**
-     * 모임 호스트 또는 매니저 권한 확인 (활성화된 모임에 대해서만)
+     * 모임 호스트 또는 매니저 권한 확인 (종료 안된 활성화된 모임에 대해서만)
      * @param clubId 모임 ID
      * @param memberId 로그인 유저 ID
      * @return 모임 호스트 또는 매니저 권한 여부
@@ -90,14 +90,14 @@ public class ClubAuthorizationChecker {
     }
 
     /**
-     * 모임 참여자 여부 확인
+     * 가입된(JOINING) 모임 참여자 여부 확인 (활성화된 모임에 대해서만)
      * @param clubId 모임 ID
      * @param memberId 로그인 유저 ID
      * @return 모임 참여자 여부
      */
     @Transactional(readOnly = true)
     public boolean isClubMember(Long clubId, Long memberId) {
-        Club club = clubService.getClub(clubId);
+        Club club = clubService.getActiveClub(clubId);
         Member member = memberService.getMember(memberId);
         return clubMemberService.existsByClubAndMember(club, member);
     }

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -89,7 +89,7 @@ public class ClubService {
                 .orElseThrow(() -> new NoSuchElementException(ClubErrorCode.CLUB_NOT_FOUND.getMessage()));
     }
     /**
-     * 모임 ID로 활성화된 모임 조회
+     * 모임 ID로 종료일 안지난 활성화된 모임 조회
      * @param clubId 모임 ID
      * @return 활성화된 모임 엔티티
      */

--- a/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
+++ b/src/main/java/com/back/domain/club/clubMember/repository/ClubMemberRepository.java
@@ -37,11 +37,17 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 
     Optional<ClubMember> findByClubAndMember(Club club, Member member);
 
+    // 특정 모임에 특정 멤버가 특정 상태로 존재하는지 확인
+    Optional<ClubMember> findByClubAndMemberAndState(Club club, Member member, ClubMemberState clubMemberState);
+
     List<ClubMember> findByClubAndState(Club club, ClubMemberState clubMemberState);
 
     List<ClubMember> findByClub(Club club);
 
     boolean existsByClubAndMember(Club club, Member member);
+
+    // 특정 모임에 특정 멤버가 특정 상태로 존재하는지 확인
+    boolean existsByClubAndMemberAndState(Club club, Member member, ClubMemberState clubMemberState);
 
     boolean existsByClubAndMemberAndRoleIn(Club club, Member member, List<ClubMemberRole> roles);
 }

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -248,13 +248,13 @@ public class ClubMemberService {
     }
 
     /**
-     * 클럽과 멤버로 클럽 멤버 조회
+     * 클럽과 멤버로 가입 완료한 클럽 멤버 조회
      * @param club 모임 엔티티
      * @param member 멤버 엔티티
      * @return 클럽 멤버 엔티티
      */
     public ClubMember getClubMember(Club club, Member member) {
-        return clubMemberRepository.findByClubAndMember(club, member)
+        return clubMemberRepository.findByClubAndMemberAndState(club, member, ClubMemberState.JOINING)
                 .orElseThrow(() -> new AccessDeniedException("권한이 없습니다."));
     }
 
@@ -265,7 +265,8 @@ public class ClubMemberService {
      * @return 클럽 멤버 존재 여부
      */
     public boolean existsByClubAndMember(Club club, Member member) {
-        return clubMemberRepository.existsByClubAndMember(club, member);
+        return clubMemberRepository
+                .existsByClubAndMemberAndState(club, member, ClubMemberState.JOINING);
     }
 
     /**

--- a/src/main/java/com/back/global/initData/TestInitData.java
+++ b/src/main/java/com/back/global/initData/TestInitData.java
@@ -13,16 +13,13 @@ import com.back.domain.club.clubMember.repository.ClubMemberRepository;
 import com.back.domain.member.friend.entity.Friend;
 import com.back.domain.member.friend.entity.FriendStatus;
 import com.back.domain.member.friend.repository.FriendRepository;
-import com.back.global.enums.MemberType;
+import com.back.global.enums.*;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.entity.MemberInfo;
 import com.back.domain.member.member.repository.MemberInfoRepository;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.schedule.schedule.entity.Schedule;
 import com.back.domain.schedule.schedule.repository.ScheduleRepository;
-import com.back.global.enums.ClubCategory;
-import com.back.global.enums.ClubMemberRole;
-import com.back.global.enums.EventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
@@ -107,10 +104,13 @@ public class TestInitData {
         members.put(member5.getNickname(), member5);
 
         Member member6 = createMember("유나영", "password6", "uny@test.com", "안녕하세요, 유나영입니다."); //가입 신청 테스트용
+        members.put(member6.getNickname(), member6);
 
         Member member7 = createMember("이채원", "password7", "lcw@test.com", "안녕하세요, 이채원입니다."); //가입 신청 테스트용
+        members.put(member7.getNickname(), member7);
 
         Member member8 = createMember("호윤호", "password8", "hyh@test.com", "안녕하세요, 호윤호입니다."); //가입 신청 테스트용
+        members.put(member8.getNickname(), member8);
 
         // 비회원
         Member guest1 = createMember("이덕혜", "password11", null, null);
@@ -187,8 +187,9 @@ public class TestInitData {
 
         ClubMember clubMember1 = ClubMember.builder()
                 .member(leader1)
-                .role(ClubMemberRole.HOST)
                 .club(club1)
+                .role(ClubMemberRole.HOST)
+                .state(ClubMemberState.JOINING)
                 .build();
         clubMemberRepository.save(clubMember1);
 
@@ -210,8 +211,9 @@ public class TestInitData {
 
         ClubMember clubMember2 = ClubMember.builder()
                 .member(leader1)
-                .role(ClubMemberRole.HOST)
                 .club(club2)
+                .role(ClubMemberRole.HOST)
+                .state(ClubMemberState.JOINING)
                 .build();
         clubMemberRepository.save(clubMember2);
 
@@ -233,8 +235,9 @@ public class TestInitData {
 
         ClubMember clubMember3 = ClubMember.builder()
                 .member(leader1)
-                .role(ClubMemberRole.HOST)
                 .club(club3)
+                .role(ClubMemberRole.HOST)
+                .state(ClubMemberState.JOINING)
                 .build();
         clubMemberRepository.save(clubMember3);
 
@@ -258,8 +261,9 @@ public class TestInitData {
 
         ClubMember clubMember4 = ClubMember.builder()
                 .member(leader2)
-                .role(ClubMemberRole.HOST)
                 .club(club4)
+                .role(ClubMemberRole.HOST)
+                .state(ClubMemberState.JOINING)
                 .build();
         clubMemberRepository.save(clubMember4);
 
@@ -282,8 +286,9 @@ public class TestInitData {
 
         ClubMember nClubMember1 = ClubMember.builder()
                 .member(leader2)
-                .role(ClubMemberRole.HOST)
                 .club(nClub1)
+                .role(ClubMemberRole.HOST)
+                .state(ClubMemberState.JOINING)
                 .build();
         clubMemberRepository.save(nClubMember1);
 
@@ -306,8 +311,9 @@ public class TestInitData {
 
         ClubMember nClubMember2 = ClubMember.builder()
                 .member(leader2)
-                .role(ClubMemberRole.HOST)
                 .club(nClub2)
+                .role(ClubMemberRole.HOST)
+                .state(ClubMemberState.JOINING)
                 .build();
         clubMemberRepository.save(nClubMember2);
     }
@@ -343,8 +349,9 @@ public class TestInitData {
 
             ClubMember clubMember = ClubMember.builder()
                     .member(member)
-                    .role(gm.role())
                     .club(club)
+                    .role(gm.role())
+                    .state(ClubMemberState.JOINING)
                     .build();
 
             clubMemberRepository.save(clubMember);


### PR DESCRIPTION
## 📢 기능 설명
- 모임 참여자 -> 활성화된(삭제 안된) 모임의 가입된(JOINNING) 참여자로 한정

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #151 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 클럽 권한 및 멤버 관련 메서드의 설명이 "종료되지 않은 활성화된 모임" 조건을 명확히 반영하도록 주석이 수정되었습니다.

* **버그 수정**
  * 클럽 멤버 조회 및 존재 여부 확인 시, '가입 완료(JOINING)' 상태의 멤버만 대상으로 하도록 동작이 변경되었습니다.

* **테스트**
  * 테스트 데이터에 클럽 멤버의 상태값(JOINING) 지정이 추가되고, 누락된 테스트 멤버가 보완되었습니다.

* **신규 기능**
  * 특정 상태의 클럽 멤버를 조회하거나 존재 여부를 확인할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->