### PR TITLE
 [refactor] 모임 로직에서 인증 방식 변경

### DIFF
--- a/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
+++ b/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
@@ -64,7 +64,11 @@ public class ApiV1ClubController {
 
     @DeleteMapping("/{clubId}")
     @Operation(summary = "클럽 삭제")
-    public RsData<Void> deleteClub(@PathVariable Long clubId) {
+    @PreAuthorize("@clubAuthorizationChecker.isActiveClubHost(#clubId, #user.id)")
+    public RsData<Void> deleteClub(
+            @PathVariable Long clubId,
+            @AuthenticationPrincipal SecurityUser user
+    ) {
         clubService.deleteClub(clubId);
         return new RsData<>(204, "클럽이 삭제됐습니다.", null);
     }

--- a/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
+++ b/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
@@ -4,6 +4,7 @@ import com.back.domain.club.club.dtos.ClubControllerDtos;
 import com.back.domain.club.club.entity.Club;
 import com.back.domain.club.club.service.ClubService;
 import com.back.global.rsData.RsData;
+import com.back.global.security.SecurityUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -12,6 +13,8 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -42,10 +45,12 @@ public class ApiV1ClubController {
 
     @PatchMapping("/{clubId}")
     @Operation(summary = "클럽 수정")
+    @PreAuthorize("@clubAuthorizationChecker.isActiveClubHost(#clubId, #user.id)")
     public RsData<ClubControllerDtos.ClubResponse> updateClubInfo(
             @PathVariable Long clubId,
             @Valid @RequestPart("data") ClubControllerDtos.UpdateClubRequest reqBody,
-            @RequestPart(value = "image", required = false) MultipartFile image
+            @RequestPart(value = "image", required = false) MultipartFile image,
+            @AuthenticationPrincipal SecurityUser user
     ) throws IOException {
         Club club = clubService.updateClub(clubId, reqBody, image);
 

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -182,9 +182,6 @@ public class ClubService {
         Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new ServiceException(404, "해당 ID의 클럽을 찾을 수 없습니다."));
 
-        // 권한 확인 : 현재 로그인한 유저가 클럽 호스트인지 확인
-        validateHostPermission(clubId);
-
         // 클럽 정보 업데이트
         String name = dto.name() != null ? dto.name() : club.getName();
         String bio = dto.bio() != null ? dto.bio() : club.getBio();

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -277,4 +277,8 @@ public class ClubService {
                                 .orElse("Unknown Leader")
                 ));
     }
+
+    public Optional<Club> findClubById(Long clubId) {
+        return clubRepository.findById(clubId);
+    }
 }

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -207,10 +207,6 @@ public class ClubService {
     }
 
     public void deleteClub(Long clubId) {
-
-        // 권한 확인 : 현재 로그인한 유저가 클럽 호스트인지 확인
-        validateHostPermission(clubId);
-
         Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new ServiceException(404, "해당 ID의 클럽을 찾을 수 없습니다."));
 

--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -3,10 +3,13 @@ package com.back.domain.club.clubMember.controller;
 import com.back.domain.club.clubMember.dtos.ClubMemberDtos;
 import com.back.domain.club.clubMember.service.ClubMemberService;
 import com.back.global.rsData.RsData;
+import com.back.global.security.SecurityUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -22,9 +25,12 @@ public class ApiV1ClubMemberController {
 
     @PostMapping
     @Operation(summary = "클럽에 멤버 추가")
+    @PreAuthorize("@clubAuthorizationChecker.isActiveClubHost(#clubId, #user.id)")
     public RsData<Void> addMembersToClub(
             @PathVariable Long clubId,
-            @RequestBody @Valid ClubMemberDtos.ClubMemberRegisterRequest reqBody
+            @RequestBody @Valid ClubMemberDtos.ClubMemberRegisterRequest reqBody,
+            @AuthenticationPrincipal SecurityUser user
+
     ) {
         clubMemberService.addMembersToClub(clubId, reqBody);
 

--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -79,9 +79,11 @@ public class ApiV1ClubMemberController {
 
     @PatchMapping("/{memberId}/approval")
     @Operation(summary = "클럽 가입 신청 승인")
+    @PreAuthorize("@clubAuthorizationChecker.isActiveClubHost(#clubId, #user.id)")
     public RsData<Void> approveMemberApplication(
             @PathVariable Long clubId,
-            @PathVariable Long memberId
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal SecurityUser user
     ) {
         clubMemberService.handleMemberApplication(clubId, memberId, true);
 
@@ -90,9 +92,11 @@ public class ApiV1ClubMemberController {
 
     @DeleteMapping("/{memberId}/approval")
     @Operation(summary = "클럽 가입 신청 거절")
+    @PreAuthorize("@clubAuthorizationChecker.isActiveClubHost(#clubId, #user.id)")
     public RsData<Void> rejectMemberApplication(
             @PathVariable Long clubId,
-            @PathVariable Long memberId
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal SecurityUser user
     ) {
         clubMemberService.handleMemberApplication(clubId, memberId, false);
 

--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -52,10 +52,12 @@ public class ApiV1ClubMemberController {
 
     @PutMapping("/{memberId}/role")
     @Operation(summary = "클럽 멤버 권한 변경")
+    @PreAuthorize("@clubAuthorizationChecker.isActiveClubHost(#clubId, #user.id)")
     public RsData<Void> changeMemberRole(
             @PathVariable Long clubId,
             @PathVariable Long memberId,
-            @RequestBody @Valid ClubMemberDtos.ClubMemberRoleChangeRequest reqBody
+            @RequestBody @Valid ClubMemberDtos.ClubMemberRoleChangeRequest reqBody,
+            @AuthenticationPrincipal SecurityUser user
     ) {
         clubMemberService.changeMemberRole(clubId, memberId, reqBody.role());
 

--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -39,9 +39,11 @@ public class ApiV1ClubMemberController {
 
     @DeleteMapping("/{memberId}")
     @Operation(summary = "클럽에서 멤버 탈퇴")
+    @PreAuthorize("@clubAuthorizationChecker.isActiveClubHost(#clubId, #user.id) || @clubAuthorizationChecker.isSelf(#memberId, #user.id)")
     public RsData<Void> withdrawMemberFromClub(
             @PathVariable Long clubId,
-            @PathVariable Long memberId
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal SecurityUser user
     ) {
         clubMemberService.withdrawMemberFromClub(clubId, memberId);
 

--- a/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
+++ b/src/main/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberController.java
@@ -66,9 +66,11 @@ public class ApiV1ClubMemberController {
 
     @GetMapping
     @Operation(summary = "클럽 멤버 목록 조회")
+    @PreAuthorize("@clubAuthorizationChecker.isClubMember(#clubId, #user.id)")
     public RsData<ClubMemberDtos.ClubMemberResponse> getClubMembers(
             @PathVariable Long clubId,
-            @RequestParam(required = false) String state // Optional: 상태 필터링
+            @RequestParam(required = false) String state, // Optional: 상태 필터링
+            @AuthenticationPrincipal SecurityUser user
     ) {
         ClubMemberDtos.ClubMemberResponse clubMemberResponse = clubMemberService.getClubMembers(clubId, state);
 

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -158,9 +158,6 @@ public class ClubMemberService {
      */
     @Transactional
     public void changeMemberRole(Long clubId, Long memberId, @NotBlank String role) {
-        // 권한 확인 : 현재 로그인한 유저가 클럽 호스트인지 확인
-        clubService.validateHostPermission(clubId);
-
         Club club = clubService.getClubById(clubId)
                 .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
         Member member = memberService.findMemberById(memberId)
@@ -177,7 +174,6 @@ public class ClubMemberService {
         if (role.equalsIgnoreCase(ClubMemberRole.HOST.name())) {
             throw new ServiceException(400, "호스트 권한은 직접 부여할 수 없습니다.");
         }
-
 
         // 역할 변경
         clubMember.updateRole(ClubMemberRole.fromString(role.toUpperCase()));

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -259,9 +259,6 @@ public class ClubMemberService {
      */
     @Transactional
     public void handleMemberApplication(Long clubId, Long memberId, boolean approve) {
-        // 권한 확인 : 현재 로그인한 유저가 클럽 호스트인지 확인
-        clubService.validateHostPermission(clubId);
-
         Club club = clubService.getClubById(clubId)
                 .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
         Member member = memberService.findMemberById(memberId)

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -192,12 +192,6 @@ public class ClubMemberService {
         Club club = clubService.getClubById(clubId)
                 .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
 
-        // 권한 확인 : 현재 로그인한 유저가 클럽 멤버인지 확인
-        Member user = rq.getActor();
-        if(!clubMemberValidService.isClubMember(clubId, user.getId()))
-            throw new ServiceException(403, "권한이 없습니다.");
-
-
         // 클럽멤버 목록 반환
         List<ClubMember> clubMembers;
         if(state != null){

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -131,14 +131,9 @@ public class ClubMemberService {
      */
     @Transactional
     public void withdrawMemberFromClub(Long clubId, Long memberId) {
-        // 권한 확인 : 현재 로그인한 유저가 클럽 호스트인지 확인
-        // 또는 탈퇴할 멤버 본인인지 확인
+        // 호스트 본인이 탈퇴하려는 경우 예외 처리
         Member user = memberService.findMemberById(rq.getActor().getId())
                 .orElseThrow(() -> new ServiceException(404, "유저가 존재하지 않습니다."));
-        if(!clubMemberValidService.checkMemberRole(clubId, user.getId(), new ClubMemberRole[]{ClubMemberRole.HOST}) && !user.getId().equals(memberId))
-            throw new ServiceException(403, "권한이 없습니다.");
-
-        // 호스트 본인이 탈퇴하려는 경우 예외 처리
         if (user.getId().equals(memberId)) {
             throw new ServiceException(400, "호스트는 탈퇴할 수 없습니다.");
         }
@@ -148,7 +143,7 @@ public class ClubMemberService {
         Member member = memberService.findMemberById(memberId)
                 .orElseThrow(() -> new ServiceException(404, "멤버가 존재하지 않습니다."));
         ClubMember clubMember = clubMemberRepository.findByClubAndMember(club, member)
-                .orElseThrow(() -> new ServiceException(404, "멤버가 존재하지 않습니다."));
+                .orElseThrow(() -> new ServiceException(404, "클럽 멤버가 존재하지 않습니다."));
 
         // 클럽에서 멤버 탈퇴
         clubMember.updateState(ClubMemberState.WITHDRAWN);

--- a/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/ClubMemberService.java
@@ -67,9 +67,6 @@ public class ClubMemberService {
         Club club = clubService.getClubById(clubId)
                 .orElseThrow(() -> new ServiceException(404, "클럽이 존재하지 않습니다."));
 
-        // 권한 확인
-        clubService.validateHostPermission(clubId);
-
         // 1. 요청 데이터에서 이메일 기준 중복 제거 (나중에 들어온 정보가 우선)
         Map<String, ClubMemberDtos.ClubMemberRegisterInfo> uniqueMemberInfoByEmail = reqBody.members().stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -33,6 +33,10 @@ public class SecurityConfig {
                                 "/api/v1/members/auth/guest-register",
                                 "/api/v1/members/auth/guest-login"
                         ).permitAll() // 회원가입, 로그인 허용
+                        .requestMatchers(
+                                "/api/v1/clubs/{clubId}",
+                                "/api/v1/clubs/public"
+                        ).permitAll() // 클럽 정보 조회 및 공개 클럽 목록 접근 허용
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화 (API 서버에서는 일반적으로 비활성화)

--- a/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
+++ b/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
@@ -259,29 +259,10 @@ class ApiV1ClubControllerTest {
     void updateClub() throws Exception {
         // given
         // 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                .name("테스트 그룹")
-                .bio("테스트 그룹 설명")
-                .category(ClubCategory.STUDY)
-                .mainSpot("서울")
-                .maximumCapacity(10)
-                .eventType(EventType.ONE_TIME)
-                .startDate(LocalDate.of(2023, 10, 1))
-                .endDate(LocalDate.of(2023, 10, 31))
-                .isPublic(true)
-                .leaderId(1L)
-                .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         // ⭐️ S3 업로더의 행동 정의: 어떤 파일이든 업로드 요청이 오면, 지정된 가짜 URL을 반환한다.
         String fakeImageUrl = "https://my-s3-bucket.s3.ap-northeast-2.amazonaws.com/club/1/profile/fake-image.jpg";
@@ -355,7 +336,7 @@ class ApiV1ClubControllerTest {
         assertThat(club.getLeaderId()).isEqualTo(1L);
         assertThat(club.isRecruitingStatus()).isFalse(); // 모집 상태가 false인지 확인
         assertThat(club.isState()).isTrue(); // 활성화 상태가 true인지 확인
-        assertThat(club.getClubMembers().size()).isEqualTo(1); // 구성원이 한명(호스트)인지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(3);
     }
 
     @Test
@@ -364,29 +345,16 @@ class ApiV1ClubControllerTest {
     void updateClubPart() throws Exception {
         // given
         // 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("수정 안 할 테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("수정 안 할 서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        String originalBio = club.getBio(); // 원래 bio 값 저장
+        ClubCategory originalCategory = club.getCategory(); // 원래 category 값 저장
+        String originalMainSpot = club.getMainSpot(); // 원래 mainSpot 값 저장
+        EventType originalEventType = club.getEventType(); // 원래 eventType 값 저장
+        Long originalLeaderId = club.getLeaderId(); // 원래 leaderId 값 저장
+
 
         // ⭐️ S3 업로더의 행동 정의: 어떤 파일이든 업로드 요청이 오면, 지정된 가짜 URL을 반환한다.
         String fakeImageUrl = "https://my-s3-bucket.s3.ap-northeast-2.amazonaws.com/club/1/profile/fake-image.jpg";
@@ -444,19 +412,19 @@ class ApiV1ClubControllerTest {
         );
 
         assertThat(club.getName()).isEqualTo("수정된 테스트 그룹");
-        assertThat(club.getBio()).isEqualTo("수정 안 할 테스트 그룹 설명");
-        assertThat(club.getCategory()).isEqualTo(ClubCategory.STUDY);
-        assertThat(club.getMainSpot()).isEqualTo( "수정 안 할 서울");
+        assertThat(club.getBio()).isEqualTo(originalBio); // bio는 수정하지 않았으므로 원래 값과 동일
+        assertThat(club.getCategory()).isEqualTo(originalCategory); // category는 수정하지 않았으므로 원래 값과 동일
+        assertThat(club.getMainSpot()).isEqualTo(originalMainSpot); // mainSpot은 수정하지 않았으므로 원래 값과 동일
         assertThat(club.getMaximumCapacity()).isEqualTo(11);
         assertThat(club.getImageUrl()).isEqualTo(fakeImageUrl); // 이미지 URL이 가짜 URL과 일치하는지 확인
-        assertThat(club.getEventType()).isEqualTo(EventType.ONE_TIME);
+        assertThat(club.getEventType()).isEqualTo(originalEventType); // eventType은 수정하지 않았으므로 원래 값과 동일
         assertThat(club.getStartDate()).isEqualTo(LocalDate.of(2024, 10, 1));
         assertThat(club.getEndDate()).isEqualTo(LocalDate.of(2024, 10, 31));
         assertThat(club.isPublic()).isTrue();
-        assertThat(club.getLeaderId()).isEqualTo(1L);
+        assertThat(club.getLeaderId()).isEqualTo(originalLeaderId); // leaderId는 수정하지 않았으므로 원래 값과 동일
         assertThat(club.isRecruitingStatus()).isFalse(); // 모집 상태가 false인지 확인
         assertThat(club.isState()).isTrue(); // 활성화 상태가 true인지 확인
-        assertThat(club.getClubMembers().size()).isEqualTo(1); // 구성원이 한명(호스트)인지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(3);
     }
 
     @Test
@@ -506,47 +474,19 @@ class ApiV1ClubControllerTest {
         resultActions
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("해당 ID의 클럽을 찾을 수 없습니다."));
+                .andExpect(jsonPath("$.message").value("모임을 찾을 수 없습니다."));
     }
 
     @Test
     @DisplayName("클럽 수정 - 권한 없는 유저")
-    @WithUserDetails(value = "chs4s@test.com") //2번 유저로 로그인
+    @WithUserDetails(value = "lyh3@test.com") //3번 유저로 로그인
     void updateClubWithoutPermission() throws Exception {
         // given
         // 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
-
-        // 클럽에 2번 유저를 멤버로 추가
-        Member member = memberService.findMemberById(2L)
-                .orElseThrow(() -> new IllegalStateException("멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                member,
-                ClubMemberRole.PARTICIPANT // 2번 유저는 PARTICIPANT 역할
-        );
 
         // 1. 가짜 이미지 파일(MockMultipartFile) 생성
         MockMultipartFile imagePart = new MockMultipartFile(

--- a/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
+++ b/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
@@ -8,7 +8,6 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.aws.S3Service;
 import com.back.global.enums.ClubCategory;
-import com.back.global.enums.ClubMemberRole;
 import com.back.global.enums.EventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -536,28 +535,10 @@ class ApiV1ClubControllerTest {
     void deleteClub() throws Exception {
         // given
         // 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
+
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -603,47 +584,19 @@ class ApiV1ClubControllerTest {
         resultActions
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
+                .andExpect(jsonPath("$.message").value("모임을 찾을 수 없습니다."));
     }
 
     @Test
     @DisplayName("클럽 정보 삭제 - 권한 없는 유저")
-    @WithUserDetails(value = "chs4s@test.com") //2번 유저로 로그인
+    @WithUserDetails(value = "lyh3@test.com") //3번 유저로 로그인
     void deleteClubWithoutPermission() throws Exception {
         // given
         // 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
-
-        // 클럽에 2번 유저를 멤버로 추가
-        Member member = memberService.findMemberById(2L)
-                .orElseThrow(() -> new IllegalStateException("멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                member,
-                ClubMemberRole.PARTICIPANT // 2번 유저는 PARTICIPANT 역할
-        );
 
         // when
         ResultActions resultActions = mvc.perform(

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -8,10 +8,8 @@ import com.back.domain.club.clubMember.service.ClubMemberService;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.aws.S3Service;
-import com.back.global.enums.ClubCategory;
 import com.back.global.enums.ClubMemberRole;
 import com.back.global.enums.ClubMemberState;
-import com.back.global.enums.EventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,8 +22,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -1048,41 +1044,22 @@ class ApiV1ClubMemberControllerTest {
     void approveMemberApplication() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
+        Member member1 = memberService.findMemberById(4L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
         // 클럽에 멤버 추가 (가입 신청 상태로)
         ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
         clubMember1.updateState(ClubMemberState.APPLYING); // 가입 신청 상태로 변경
-        clubMemberRepository.save(clubMember1); // 상태 변경된 클럽 멤버 저장
+        clubMemberRepository.saveAndFlush(clubMember1); // 상태 변경된 클럽 멤버 저장
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 2명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(4); // 클럽에 멤버가 2명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1111,36 +1088,14 @@ class ApiV1ClubMemberControllerTest {
     void approveMemberApplication_NotAppliedMember() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
+        Member member1 = memberService.findMemberById(4L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
-
-        assertThat(club.getClubMembers().size()).isEqualTo(1); // 클럽에 멤버가 2명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1164,41 +1119,14 @@ class ApiV1ClubMemberControllerTest {
     void approveMemberApplication_AlreadyJoinedMember() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         // 추가할 멤버 (testInitData의 멤버 사용)
         Member member1 = memberService.findMemberById(2L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
-
-        // 클럽에 멤버 추가 (가입 상태로)
-        ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
-        clubMember1.updateState(ClubMemberState.JOINING); // JOINING 상태로 변경
-        clubMemberRepository.save(clubMember1); // 상태 변경된 클럽 멤버 저장
-
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 2명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1222,41 +1150,21 @@ class ApiV1ClubMemberControllerTest {
     void approveMemberApplication_WithdrawnMember() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
+        Member member1 = memberService.findMemberById(4L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
         // 클럽에 멤버 추가 (탈퇴 상태로)
         ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
         clubMember1.updateState(ClubMemberState.WITHDRAWN); // WITHDRAWN 상태로 변경
-        clubMemberRepository.save(clubMember1); // 상태 변경된 클럽 멤버 저장
+        clubMemberRepository.saveAndFlush(clubMember1); // 상태 변경된 클럽 멤버 저장
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 2명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(4); // 클럽에 멤버가 2명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1280,41 +1188,21 @@ class ApiV1ClubMemberControllerTest {
     void approveMemberApplication_InvitedMember() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
+        Member member1 = memberService.findMemberById(4L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
         // 클럽에 멤버 추가 (초대됨 상태로)
         ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
         clubMember1.updateState(ClubMemberState.INVITED); // INVITED 상태로 변경
-        clubMemberRepository.save(clubMember1); // 상태 변경된 클럽 멤버 저장
+        clubMemberRepository.saveAndFlush(clubMember1); // 상태 변경된 클럽 멤버 저장
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 2명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(4); // 클럽에 멤버가 2명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1334,55 +1222,25 @@ class ApiV1ClubMemberControllerTest {
 
     @Test
     @DisplayName("가입 신청 수락 - 권한 없는 멤버")
-    @WithUserDetails(value = "hgd222@test.com") // 1번 멤버로 로그인
+    @WithUserDetails(value = "chs4s@test.com") // 2번 멤버로 로그인
     void approveMemberApplication_UnauthorizedMember() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(2L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
-
-        // 클럽에 호스트가 아닌 멤버 추가
-        Member nonHostMember = memberService.findMemberById(1L).orElseThrow(
-                () -> new IllegalStateException("호스트가 아닌 멤버가 존재하지 않습니다.")
-        );
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                nonHostMember,
-                ClubMemberRole.PARTICIPANT
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(3L).orElseThrow(
+        Member member1 = memberService.findMemberById(4L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
         // 클럽에 멤버 추가 (가입 신청 상태로)
         ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
         clubMember1.updateState(ClubMemberState.APPLYING); // 가입 신청 상태로 변경
-        clubMemberRepository.save(clubMember1); // 상태 변경된 클럽 멤버 저장
+        clubMemberRepository.saveAndFlush(clubMember1); // 상태 변경된 클럽 멤버 저장
 
-        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 2명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(4);
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1425,7 +1283,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(handler().methodName("approveMemberApplication"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
+                .andExpect(jsonPath("$.message").value("모임을 찾을 수 없습니다."));
     }
 
     @Test
@@ -1434,32 +1292,13 @@ class ApiV1ClubMemberControllerTest {
     void rejectJoinRequest() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
+        Member member1 = memberService.findMemberById(4L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
@@ -1468,7 +1307,7 @@ class ApiV1ClubMemberControllerTest {
         clubMember1.updateState(ClubMemberState.APPLYING); // 가입 신청 상태로 변경
         clubMemberRepository.save(clubMember1); // 상태 변경된 클럽 멤버 저장
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 2명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(4); // 클럽에 멤버가 2명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1486,7 +1325,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(jsonPath("$.message").value("가입 신청이 거절됐습니다."));
 
         // 클럽 멤버가 삭제됐는지 확인
-        assertThat(club.getClubMembers().size()).isEqualTo(1); // 클럽에 멤버가 1명(호스트) 남아있는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 1명(호스트) 남아있는지 확인
         assertThat(clubMemberRepository.existsById(clubMember1.getId())).isFalse(); // 클럽 멤버가 삭제되었는지 확인
     }
 

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -365,7 +365,7 @@ class ApiV1ClubMemberControllerTest {
     void addMemberToClub_ExceedMaximumCapacity() throws Exception {
         // given
         // 테스트 클럽 생성
-        Long clubId = 2L; // 테스트를 위해 클럽 ID를 1로 고정
+        Long clubId = 2L; // 테스트를 위해 클럽 ID를 2로 고정
         Club club = clubService.findClubById(clubId)
                 .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
@@ -423,39 +423,17 @@ class ApiV1ClubMemberControllerTest {
     void withdrawMemberFromClub() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
 
-        // 추가할 멤버 (testInitData의 멤버 사용)
+        // 탈퇴할 멤버 (testInitData의 멤버 사용)
         Member member1 = memberService.findMemberById(2L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
-        // 클럽에 멤버 추가
-        clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
-
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 1명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 1명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -477,9 +455,9 @@ class ApiV1ClubMemberControllerTest {
                 () -> new IllegalStateException("클럽이 존재하지 않습니다.")
         );
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 여전히 존재해야 함
+        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 여전히 존재해야 함
         assertThat(club.getClubMembers().get(1).getMember().getEmail()).isEqualTo(member1.getEmail());
-        assertThat(club.getClubMembers().get(1).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT);
+        assertThat(club.getClubMembers().get(1).getRole()).isEqualTo(ClubMemberRole.MANAGER);
         assertThat(club.getClubMembers().get(1).getState()).isEqualTo(ClubMemberState.WITHDRAWN); // 상태가 WITHDRAWN으로 변경되었는지 확인
     }
 
@@ -504,7 +482,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(handler().methodName("withdrawMemberFromClub"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
+                .andExpect(jsonPath("$.message").value("모임을 찾을 수 없습니다."));
     }
 
     @Test
@@ -513,22 +491,11 @@ class ApiV1ClubMemberControllerTest {
     void withdrawMemberFromClub_MemberNotFound() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        Long nonExistentMemberId = 9999L; // 존재하지 않는 멤버 ID
+        Long nonExistentMemberId = 5L; // 존재하지 않는 멤버 ID
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -552,45 +519,15 @@ class ApiV1ClubMemberControllerTest {
     void withdrawMemberFromClub_UnauthorizedMember() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
 
-        // 클럽에 호스트가 아닌 멤버 추가
-        Member unauthorizedMember = memberService.findMemberById(2L).orElseThrow(
-                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
-        );
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                unauthorizedMember,
-                ClubMemberRole.PARTICIPANT
-        );
-
-        // 추가할 멤버 (testInitData의 멤버 사용)
+        // 탈퇴할 멤버 (testInitData의 멤버 사용)
         Member member1 = memberService.findMemberById(3L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
-        clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
 
         assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 3명 추가되었는지 확인
 
@@ -616,33 +553,14 @@ class ApiV1ClubMemberControllerTest {
     void withdrawHostFromClub() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
 
         // when
         ResultActions resultActions = mvc.perform(
-                        delete("/api/v1/clubs/" + club.getId() + "/members/" + hostMember.getId())
+                        delete("/api/v1/clubs/" + club.getId() + "/members/" + 1L)
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -580,39 +580,22 @@ class ApiV1ClubMemberControllerTest {
     void changeMemberRole() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
 
-        // 클럽에 호스트 멤버 추가
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
+
         Member hostMember = memberService.findMemberById(1L)
                 .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
 
-        // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
+
+        // 권한 변경할 멤버 (testInitData의 멤버 사용)
+        Member member1 = memberService.findMemberById(3L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
-        // 클럽에 멤버 추가
-        clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
-
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 1명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(3);
+        assertThat(club.getClubMembers().get(2).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT); // 참여자 역할 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -635,11 +618,11 @@ class ApiV1ClubMemberControllerTest {
                 () -> new IllegalStateException("클럽이 존재하지 않습니다.")
         );
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2);
+        assertThat(club.getClubMembers().size()).isEqualTo(3);
         assertThat(club.getClubMembers().get(0).getMember().getEmail()).isEqualTo(hostMember.getEmail());
         assertThat(club.getClubMembers().get(0).getRole()).isEqualTo(ClubMemberRole.HOST);
-        assertThat(club.getClubMembers().get(1).getMember().getEmail()).isEqualTo(member1.getEmail());
-        assertThat(club.getClubMembers().get(1).getRole()).isEqualTo(ClubMemberRole.MANAGER); // 역할이 MANAGER로 변경되었는지 확인
+        assertThat(club.getClubMembers().get(2).getMember().getEmail()).isEqualTo(member1.getEmail());
+        assertThat(club.getClubMembers().get(2).getRole()).isEqualTo(ClubMemberRole.MANAGER); // 역할이 MANAGER로 변경되었는지 확인
     }
 
     @Test
@@ -664,7 +647,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(handler().methodName("changeMemberRole"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
+                .andExpect(jsonPath("$.message").value("모임을 찾을 수 없습니다."));
     }
 
     @Test
@@ -673,28 +656,9 @@ class ApiV1ClubMemberControllerTest {
     void changeMemberRole_MemberNotFound() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         Long nonExistentMemberId = 9999L; // 존재하지 않는 멤버 ID
 
@@ -721,38 +685,17 @@ class ApiV1ClubMemberControllerTest {
     void changeMemberRole_InvalidRole() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
+
 
         // 추가할 멤버 (testInitData의 멤버 사용)
         Member member1 = memberService.findMemberById(2L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
-        // 클럽에 멤버 추가
-        clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
-
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 1명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 1명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -777,47 +720,14 @@ class ApiV1ClubMemberControllerTest {
     void changeMemberRole_UnauthorizedMember() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
-
-        // 클럽에 호스트가 아닌 멤버 추가
-        Member unauthorizedMember = memberService.findMemberById(2L).orElseThrow(
-                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
-        );
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                unauthorizedMember,
-                ClubMemberRole.PARTICIPANT
-        );
-
-        // 추가할 멤버 (testInitData의 멤버 사용)
+        // 권한 변경할 멤버 (testInitData의 멤버 사용)
         Member member1 = memberService.findMemberById(3L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
-
-        // 클럽에 멤버 추가
-        clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
 
         assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 3명 추가되었는지 확인
 
@@ -844,33 +754,15 @@ class ApiV1ClubMemberControllerTest {
     void changeHostRole() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+
 
         // when
         ResultActions resultActions = mvc.perform(
-                        put("/api/v1/clubs/" + club.getId() + "/members/" + hostMember.getId() + "/role")
+                        put("/api/v1/clubs/" + club.getId() + "/members/" + 1L + "/role")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("{\"role\": \"MANAGER\"}")
                 )
@@ -891,39 +783,15 @@ class ApiV1ClubMemberControllerTest {
     void changeMemberRole_ToHost() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
 
-        // 추가할 멤버 (testInitData의 멤버 사용)
+        // 권한 변경할 멤버 (testInitData의 멤버 사용)
         Member member1 = memberService.findMemberById(2L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
-
-        // 클럽에 멤버 추가
-        clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
-
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 1명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -5,7 +5,6 @@ import com.back.domain.club.club.service.ClubService;
 import com.back.domain.club.clubMember.entity.ClubMember;
 import com.back.domain.club.clubMember.repository.ClubMemberRepository;
 import com.back.domain.club.clubMember.service.ClubMemberService;
-import com.back.global.enums.MemberType;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.aws.S3Service;
@@ -816,53 +815,20 @@ class ApiV1ClubMemberControllerTest {
     void getClubMembers() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-        // 클럽에 호스트 멤버 추가
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
+
         Member hostMember = memberService.findMemberById(1L)
                 .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        // 클럽 멤버들 (testInitData의 멤버 사용)
+        Member member1 = memberService.findMemberById(2L)
+                .orElseThrow(() -> new IllegalStateException("멤버가 존재하지 않습니다."));
+        Member member2 = memberService.findMemberById(3L)
+                .orElseThrow(() -> new IllegalStateException("멤버가 존재하지 않습니다."));
 
-        // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
-                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
-        );
-
-        Member member2 = memberService.findMemberById(3L).orElseThrow(
-                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
-        );
-
-        // 비회원 멤버 추가
-        Member nonMember = Member.builder()
-                .id(4L)
-                .nickname("비회원")
-                .password("password")
-                .memberType(MemberType.GUEST)
-                .tag("123456")
-                .build();
-
-        // 클럽에 멤버 추가
-        ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
-        ClubMember clubMember2 = clubMemberService.addMemberToClub(club.getId(), member2, ClubMemberRole.MANAGER);
-        ClubMember nonMemberClubMember = clubMemberService.addMemberToClub(club.getId(), nonMember, ClubMemberRole.PARTICIPANT);
-
-        assertThat(club.getClubMembers().size()).isEqualTo(4); // 클럽에 멤버가 4명 추가되었는지 확인
+        ClubMember clubMember1 = club.getClubMembers().get(1);
+        ClubMember clubMember2 = club.getClubMembers().get(2);
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -878,7 +844,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("클럽 멤버 목록이 조회됐습니다."))
-                .andExpect(jsonPath("$.data.members.length()").value(4)) // 멤버가 4명인지 확인
+                .andExpect(jsonPath("$.data.members.length()").value(3)) // 멤버가 4명인지 확인
 
                 .andExpect(jsonPath("$.data.members[0].memberId").value(hostMember.getId()))
                 .andExpect(jsonPath("$.data.members[0].nickname").value(hostMember.getNickname()))
@@ -893,7 +859,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(jsonPath("$.data.members[1].memberId").value(member1.getId()))
                 .andExpect(jsonPath("$.data.members[1].nickname").value(member1.getNickname()))
                 .andExpect(jsonPath("$.data.members[1].tag").value(member1.getTag()))
-                .andExpect(jsonPath("$.data.members[1].role").value(ClubMemberRole.PARTICIPANT.name()))
+                .andExpect(jsonPath("$.data.members[1].role").value(clubMember1.getRole().name()))
                 .andExpect(jsonPath("$.data.members[1].email").value(member1.getEmail()))
                 .andExpect(jsonPath("$.data.members[1].memberType").value(member1.getMemberType().name()))
                 .andExpect(jsonPath("$.data.members[1].profileImageUrl").value(""))
@@ -903,21 +869,11 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(jsonPath("$.data.members[2].memberId").value(member2.getId()))
                 .andExpect(jsonPath("$.data.members[2].nickname").value(member2.getNickname()))
                 .andExpect(jsonPath("$.data.members[2].tag").value(member2.getTag()))
-                .andExpect(jsonPath("$.data.members[2].role").value(ClubMemberRole.MANAGER.name()))
+                .andExpect(jsonPath("$.data.members[2].role").value(clubMember2.getRole().name()))
                 .andExpect(jsonPath("$.data.members[2].email").value(member2.getEmail()))
                 .andExpect(jsonPath("$.data.members[2].memberType").value(member2.getMemberType().name()))
                 .andExpect(jsonPath("$.data.members[2].profileImageUrl").value(""))
-                .andExpect(jsonPath("$.data.members[2].state").value(clubMember2.getState().name()))
-
-                .andExpect(jsonPath("$.data.members[3].clubMemberId").value(nonMemberClubMember.getId()))
-                .andExpect(jsonPath("$.data.members[3].memberId").value(nonMember.getId()))
-                .andExpect(jsonPath("$.data.members[3].nickname").value(nonMember.getNickname()))
-                .andExpect(jsonPath("$.data.members[3].tag").value(nonMember.getTag()))
-                .andExpect(jsonPath("$.data.members[3].role").value(ClubMemberRole.PARTICIPANT.name()))
-                .andExpect(jsonPath("$.data.members[3].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data.members[3].memberType").value(nonMember.getMemberType().name()))
-                .andExpect(jsonPath("$.data.members[3].profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data.members[3].state").value(nonMemberClubMember.getState().name())); // 비회원의 상태 확인
+                .andExpect(jsonPath("$.data.members[2].state").value(clubMember2.getState().name()));
     }
 
     @Test
@@ -926,57 +882,24 @@ class ApiV1ClubMemberControllerTest {
     void getClubMembers_stateFiltered() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 추가할 멤버 (testInitData의 멤버 사용)
+
         Member member1 = memberService.findMemberById(2L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
-
         Member member2 = memberService.findMemberById(3L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
-        // 비회원 멤버 추가
-        Member nonMember = Member.builder()
-                .id(4L)
-                .nickname("비회원")
-                .password("password")
-                .memberType(MemberType.GUEST)
-                .tag("123456")
-                .build();
-
-        // 클럽에 멤버 추가
-        ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
-        ClubMember clubMember2 = clubMemberService.addMemberToClub(club.getId(), member2, ClubMemberRole.MANAGER);
-        ClubMember nonMemberClubMember = clubMemberService.addMemberToClub(club.getId(), nonMember, ClubMemberRole.PARTICIPANT);
-
-        assertThat(club.getClubMembers().size()).isEqualTo(4); // 클럽에 멤버가 4명 추가되었는지 확인
+        ClubMember clubMember1 = club.getClubMembers().get(1); // member1의 클럽 멤버
+        ClubMember clubMember2 = club.getClubMembers().get(2); // member2의 클럽 멤버
 
         // 클럽 멤버의 상태 변경
-        clubMember2.updateState(ClubMemberState.JOINING); // member2를 JOINING 상태로 변경
-        clubMemberRepository.save(clubMember2); // 상태 변경된 클럽 멤버 저장
+        clubMember1.updateState(ClubMemberState.INVITED); // member2를 JOINING 상태로 변경
+        clubMemberRepository.saveAndFlush(clubMember1); // 상태 변경된 클럽 멤버 저장
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -992,36 +915,16 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("클럽 멤버 목록이 조회됐습니다."))
-                .andExpect(jsonPath("$.data.members.length()").value(3)) // 멤버가 3명인지 확인
+                .andExpect(jsonPath("$.data.members.length()").value(1)) // 멤버가 3명인지 확인
 
-                .andExpect(jsonPath("$.data.members[0].memberId").value(hostMember.getId()))
-                .andExpect(jsonPath("$.data.members[0].nickname").value(hostMember.getNickname()))
-                .andExpect(jsonPath("$.data.members[0].tag").value(hostMember.getTag()))
-                .andExpect(jsonPath("$.data.members[0].role").value(ClubMemberRole.HOST.name()))
-                .andExpect(jsonPath("$.data.members[0].email").value(hostMember.getEmail()))
-                .andExpect(jsonPath("$.data.members[0].memberType").value(hostMember.getMemberType().name()))
-                .andExpect(jsonPath("$.data.members[0].profileImageUrl").value("")) // 호스트는 이미지 URL이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data.members[0].state").value(club.getClubMembers().get(0).getState().name())) // 호스트의 상태 확인
-
-                .andExpect(jsonPath("$.data.members[1].clubMemberId").value(clubMember1.getId()))
-                .andExpect(jsonPath("$.data.members[1].memberId").value(member1.getId()))
-                .andExpect(jsonPath("$.data.members[1].nickname").value(member1.getNickname()))
-                .andExpect(jsonPath("$.data.members[1].tag").value(member1.getTag()))
-                .andExpect(jsonPath("$.data.members[1].role").value(ClubMemberRole.PARTICIPANT.name()))
-                .andExpect(jsonPath("$.data.members[1].email").value(member1.getEmail()))
-                .andExpect(jsonPath("$.data.members[1].memberType").value(member1.getMemberType().name()))
-                .andExpect(jsonPath("$.data.members[1].profileImageUrl").value(""))
-                .andExpect(jsonPath("$.data.members[1].state").value(clubMember1.getState().name()))
-
-                .andExpect(jsonPath("$.data.members[2].clubMemberId").value(nonMemberClubMember.getId()))
-                .andExpect(jsonPath("$.data.members[2].memberId").value(nonMember.getId()))
-                .andExpect(jsonPath("$.data.members[2].nickname").value(nonMember.getNickname()))
-                .andExpect(jsonPath("$.data.members[2].tag").value(nonMember.getTag()))
-                .andExpect(jsonPath("$.data.members[2].role").value(ClubMemberRole.PARTICIPANT.name()))
-                .andExpect(jsonPath("$.data.members[2].email").value("")) // 비회원은 이메일이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data.members[2].memberType").value(nonMember.getMemberType().name()))
-                .andExpect(jsonPath("$.data.members[2].profileImageUrl").value("")) // 비회원은 이미지 URL이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data.members[2].state").value(nonMemberClubMember.getState().name())); // 비회원의 상태 확인
+                .andExpect(jsonPath("$.data.members[0].memberId").value(member1.getId()))
+                .andExpect(jsonPath("$.data.members[0].nickname").value(member1.getNickname()))
+                .andExpect(jsonPath("$.data.members[0].tag").value(member1.getTag()))
+                .andExpect(jsonPath("$.data.members[0].role").value(clubMember1.getRole().name()))
+                .andExpect(jsonPath("$.data.members[0].email").value(member1.getEmail()))
+                .andExpect(jsonPath("$.data.members[0].memberType").value(member1.getMemberType().name()))
+                .andExpect(jsonPath("$.data.members[0].profileImageUrl").value("")) // 이미지 URL이 없으므로 빈 문자열
+                .andExpect(jsonPath("$.data.members[0].state").value(clubMember1.getState().name())); // 호스트의 상태 확인
     }
 
     @Test
@@ -1044,7 +947,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(handler().methodName("getClubMembers"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
+                .andExpect(jsonPath("$.message").value("모임을 찾을 수 없습니다."));
     }
 
     @Test
@@ -1053,29 +956,9 @@ class ApiV1ClubMemberControllerTest {
     void getClubMembers_InvalidStateFilter() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1099,43 +982,30 @@ class ApiV1ClubMemberControllerTest {
     void getClubMembers_WithdrawStateFilter() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
         Member hostMember = memberService.findMemberById(1L)
                 .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
 
-        // 추가할 멤버 (testInitData의 멤버 사용)
         Member member1 = memberService.findMemberById(2L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
-        // 클럽에 멤버 추가
-        ClubMember clubMember1 = clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
+        Member member2 = memberService.findMemberById(3L).orElseThrow(
+                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
+        );
+
+        ClubMember clubMember1 = club.getClubMembers().get(1); // member1의 클럽 멤버
+        ClubMember clubMember2 = club.getClubMembers().get(2); // member2의 클럽 멤버
+
 
         // 클럽 멤버 상태를 WITHDRAWN으로 변경
         clubMember1.updateState(ClubMemberState.WITHDRAWN);
-        clubMemberRepository.save(clubMember1); // 상태 변경된 클럽 멤버 저장
+        clubMemberRepository.saveAndFlush(clubMember1); // 상태 변경된 클럽 멤버 저장
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 2명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 2명 추가되었는지 확인
 
         // when
         ResultActions resultActions = mvc.perform(
@@ -1151,7 +1021,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("클럽 멤버 목록이 조회됐습니다."))
-                .andExpect(jsonPath("$.data.members.length()").value(1)) // 멤버가 1명(Host)인지 확인
+                .andExpect(jsonPath("$.data.members.length()").value(2)) // 멤버가 1명(Host)인지 확인
                 .andExpect(jsonPath("$.data.members[0].memberId").value(hostMember.getId()))
                 .andExpect(jsonPath("$.data.members[0].nickname").value(hostMember.getNickname()))
                 .andExpect(jsonPath("$.data.members[0].tag").value(hostMember.getTag()))
@@ -1159,7 +1029,17 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(jsonPath("$.data.members[0].email").value(hostMember.getEmail()))
                 .andExpect(jsonPath("$.data.members[0].memberType").value(hostMember.getMemberType().name()))
                 .andExpect(jsonPath("$.data.members[0].profileImageUrl").value("")) // 호스트는 이미지 URL이 없으므로 빈 문자열
-                .andExpect(jsonPath("$.data.members[0].state").value(club.getClubMembers().get(0).getState().name())); // 호스트의 상태 확인
+                .andExpect(jsonPath("$.data.members[0].state").value(club.getClubMembers().get(0).getState().name())) // 호스트의 상태 확인
+
+                .andExpect(jsonPath("$.data.members[1].clubMemberId").value(clubMember2.getId()))
+                .andExpect(jsonPath("$.data.members[1].memberId").value(member2.getId()))
+                .andExpect(jsonPath("$.data.members[1].nickname").value(member2.getNickname()))
+                .andExpect(jsonPath("$.data.members[1].tag").value(member2.getTag()))
+                .andExpect(jsonPath("$.data.members[1].role").value(clubMember2.getRole().name()))
+                .andExpect(jsonPath("$.data.members[1].email").value(member2.getEmail()))
+                .andExpect(jsonPath("$.data.members[1].memberType").value(member2.getMemberType().name()))
+                .andExpect(jsonPath("$.data.members[1].profileImageUrl").value(""))
+                .andExpect(jsonPath("$.data.members[1].state").value(clubMember2.getState().name())); // 참여자의 상태 확인
     }
 
     @Test
@@ -1547,7 +1427,6 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(jsonPath("$.code").value(404))
                 .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
     }
-
 
     @Test
     @DisplayName("가입 신청 거절")

--- a/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
+++ b/src/test/java/com/back/domain/club/clubMember/controller/ApiV1ClubMemberControllerTest.java
@@ -59,37 +59,19 @@ class ApiV1ClubMemberControllerTest {
     void addMemberToClub() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
         Member hostMember = memberService.findMemberById(1L)
                 .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
-
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
+        Member member1 = memberService.findMemberById(4L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
-        Member member2 = memberService.findMemberById(3L).orElseThrow(
+        Member member2 = memberService.findMemberById(5L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
@@ -130,13 +112,13 @@ class ApiV1ClubMemberControllerTest {
                 () -> new IllegalStateException("클럽이 존재하지 않습니다.")
         );
 
-        assertThat(club.getClubMembers().size()).isEqualTo(3); // 멤버가 총 3명 인지 확인 (호스트 포함)
+        assertThat(club.getClubMembers().size()).isEqualTo(5); // 멤버가 총 3명 인지 확인 (호스트 포함)
         assertThat(club.getClubMembers().get(0).getMember().getEmail()).isEqualTo(hostMember.getEmail());
         assertThat(club.getClubMembers().get(0).getRole()).isEqualTo(ClubMemberRole.HOST);
-        assertThat(club.getClubMembers().get(1).getMember().getEmail()).isEqualTo(member1.getEmail());
-        assertThat(club.getClubMembers().get(1).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT);
-        assertThat(club.getClubMembers().get(2).getMember().getEmail()).isEqualTo(member2.getEmail());
-        assertThat(club.getClubMembers().get(2).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT);
+        assertThat(club.getClubMembers().get(4).getMember().getEmail()).isEqualTo(member1.getEmail());
+        assertThat(club.getClubMembers().get(4).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT);
+        assertThat(club.getClubMembers().get(3).getMember().getEmail()).isEqualTo(member2.getEmail());
+        assertThat(club.getClubMembers().get(3).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT);
     }
 
     @Test
@@ -145,32 +127,13 @@ class ApiV1ClubMemberControllerTest {
     void addMemberToClub_DuplicateMember() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
+        Member member1 = memberService.findMemberById(4L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
@@ -211,11 +174,9 @@ class ApiV1ClubMemberControllerTest {
                 () -> new IllegalStateException("클럽이 존재하지 않습니다.")
         );
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 중복된 멤버는 하나만 추가
-        assertThat(club.getClubMembers().get(0).getMember().getEmail()).isEqualTo(hostMember.getEmail());
-        assertThat(club.getClubMembers().get(0).getRole()).isEqualTo(ClubMemberRole.HOST);
-        assertThat(club.getClubMembers().get(1).getMember().getEmail()).isEqualTo(member1.getEmail());
-        assertThat(club.getClubMembers().get(1).getRole()).isEqualTo(ClubMemberRole.MANAGER); // 나중에 추가한 역할이 유지됨
+        assertThat(club.getClubMembers().size()).isEqualTo(4); // 중복된 멤버는 하나만 추가
+        assertThat(club.getClubMembers().get(3).getMember().getEmail()).isEqualTo(member1.getEmail());
+        assertThat(club.getClubMembers().get(3).getRole()).isEqualTo(ClubMemberRole.MANAGER); // 나중에 추가한 역할이 유지됨
     }
 
     @Test
@@ -224,40 +185,19 @@ class ApiV1ClubMemberControllerTest {
     void addMemberToClub_AlreadyAddedMember() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
         Member hostMember = memberService.findMemberById(1L)
                 .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
-
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(2L).orElseThrow(
+        Member member1 = memberService.findMemberById(3L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
-        // 클럽에 멤버 추가
-        clubMemberService.addMemberToClub(club.getId(), member1, ClubMemberRole.PARTICIPANT);
-
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 1명 추가되었는지 확인
+        assertThat(club.getClubMembers().size()).isEqualTo(3);
 
         // JSON 데이터 파트 생성
         String jsonData = """
@@ -292,11 +232,11 @@ class ApiV1ClubMemberControllerTest {
                 () -> new IllegalStateException("클럽이 존재하지 않습니다.")
         );
 
-        assertThat(club.getClubMembers().size()).isEqualTo(2);
+        assertThat(club.getClubMembers().size()).isEqualTo(3);
         assertThat(club.getClubMembers().get(0).getMember().getEmail()).isEqualTo(hostMember.getEmail());
         assertThat(club.getClubMembers().get(0).getRole()).isEqualTo(ClubMemberRole.HOST);
-        assertThat(club.getClubMembers().get(1).getMember().getEmail()).isEqualTo(member1.getEmail());
-        assertThat(club.getClubMembers().get(1).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT);
+        assertThat(club.getClubMembers().get(2).getMember().getEmail()).isEqualTo(member1.getEmail());
+        assertThat(club.getClubMembers().get(2).getRole()).isEqualTo(ClubMemberRole.PARTICIPANT);
     }
 
     @Test
@@ -329,7 +269,7 @@ class ApiV1ClubMemberControllerTest {
                 .andExpect(handler().methodName("addMembersToClub"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("클럽이 존재하지 않습니다."));
+                .andExpect(jsonPath("$.message").value("모임을 찾을 수 없습니다."));
     }
 
     @Test
@@ -337,29 +277,9 @@ class ApiV1ClubMemberControllerTest {
     @WithUserDetails(value = "hgd222@test.com") // 1번 멤버로 로그인
     void addMemberToClub_MemberNotFound() throws Exception {
         // given
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         String jsonData = """
                 {
@@ -393,39 +313,9 @@ class ApiV1ClubMemberControllerTest {
     @DisplayName("클럽에 멤버 추가 - 권한 없는 멤버")
     @WithUserDetails(value = "chs4s@test.com") // 2번 멤버로 로그인 (호스트가 아님)
     void addMemberToClub_UnauthorizedMember() throws Exception {
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(10)
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
-
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
-
-        // 클럽에 호스트가 아닌 멤버 추가
-        Member unauthorizedMember = memberService.findMemberById(2L).orElseThrow(
-                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
-        );
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                unauthorizedMember,
-                ClubMemberRole.PARTICIPANT
-        );
+        Long clubId = 1L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
         // 추가할 멤버 (testInitData의 멤버 사용)
         Member member1 = memberService.findMemberById(3L).orElseThrow(
@@ -475,42 +365,13 @@ class ApiV1ClubMemberControllerTest {
     void addMemberToClub_ExceedMaximumCapacity() throws Exception {
         // given
         // 테스트 클럽 생성
-        Club club = clubService.createClub(
-                Club.builder()
-                        .name("테스트 그룹")
-                        .bio("테스트 그룹 설명")
-                        .category(ClubCategory.STUDY)
-                        .mainSpot("서울")
-                        .maximumCapacity(2) // 정원을 2명으로 설정
-                        .eventType(EventType.ONE_TIME)
-                        .startDate(LocalDate.of(2023, 10, 1))
-                        .endDate(LocalDate.of(2023, 10, 31))
-                        .isPublic(true)
-                        .leaderId(1L)
-                        .build()
-        );
+        Long clubId = 2L; // 테스트를 위해 클럽 ID를 1로 고정
+        Club club = clubService.findClubById(clubId)
+                .orElseThrow(() -> new IllegalStateException("클럽이 존재하지 않습니다."));
 
-        // 클럽에 호스트 멤버 추가
-        Member hostMember = memberService.findMemberById(1L)
-                .orElseThrow(() -> new IllegalStateException("호스트 멤버가 존재하지 않습니다."));
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                hostMember,
-                ClubMemberRole.HOST
-        );
-
-        // 클럽에 호스트가 아닌 멤버 추가
-        Member unauthorizedMember = memberService.findMemberById(2L).orElseThrow(
-                () -> new IllegalStateException("멤버가 존재하지 않습니다.")
-        );
-        clubMemberService.addMemberToClub(
-                club.getId(),
-                unauthorizedMember,
-                ClubMemberRole.PARTICIPANT
-        );
 
         // 추가할 멤버 (testInitData의 멤버 사용)
-        Member member1 = memberService.findMemberById(3L).orElseThrow(
+        Member member1 = memberService.findMemberById(2L).orElseThrow(
                 () -> new IllegalStateException("멤버가 존재하지 않습니다.")
         );
 
@@ -553,7 +414,7 @@ class ApiV1ClubMemberControllerTest {
         club = clubService.getClubById(club.getId()).orElseThrow(
                 () -> new IllegalStateException("클럽이 존재하지 않습니다.")
         );
-        assertThat(club.getClubMembers().size()).isEqualTo(2); // 클럽에 멤버가 2명만 있어야 함 (호스트 + 참여자)
+        assertThat(club.getClubMembers().size()).isEqualTo(3); // 클럽에 멤버가 2명만 있어야 함 (호스트 + 참여자)
     }
 
     @Test


### PR DESCRIPTION
## 📢 기능 설명
- 클럽 관리 CRUD에 pre-authorization을 통한 인증,인가 로직 추가
- 클럽 멤버 관리 CRUD에 pre-authorization을 통한 인증,인가 로직 추가
- 기존 인증, 인가 로직 삭제
- 관련 테스트 케이스 수정
<br>

## 연결된 issue
close #141 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 클럽 및 클럽 멤버 관리 API에 역할 기반 접근 제어(호스트/멤버 등) 인증 및 권한 검증이 추가되었습니다.

* **버그 수정**
  * 일부 오류 메시지 및 테스트 데이터가 실제 상태와 일치하도록 수정되었습니다.

* **테스트**
  * 테스트 코드가 기존에 생성하던 테스트 데이터를 미리 준비된 고정 데이터로 대체하여 일관성을 높였습니다.
  * 테스트 내 예상 멤버 수, 멤버 ID, 오류 메시지 등이 실제 데이터와 맞게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->