### PR TITLE
[Refactor] 일정 dto 추가 및 변경, 쿼리 변경

### DIFF
--- a/src/main/java/com/back/domain/checkList/checkList/checker/CheckListAuthorizationChecker.java
+++ b/src/main/java/com/back/domain/checkList/checkList/checker/CheckListAuthorizationChecker.java
@@ -99,7 +99,7 @@ public class CheckListAuthorizationChecker {
 
     private Club getClubByScheduleId(Long scheduleId) {
         // Schedule 엔티티 조회
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Schedule schedule = scheduleService.getActiveScheduleEntityById(scheduleId);
 
         if (schedule == null || !schedule.isActive()) {
             throw new NoSuchElementException("일정을 찾을 수 없습니다.");

--- a/src/main/java/com/back/domain/checkList/checkList/dto/CheckListDto.java
+++ b/src/main/java/com/back/domain/checkList/checkList/dto/CheckListDto.java
@@ -1,7 +1,7 @@
 package com.back.domain.checkList.checkList.dto;
 
 import com.back.domain.checkList.checkList.entity.CheckList;
-import com.back.domain.schedule.schedule.dto.ScheduleDto;
+import com.back.domain.schedule.schedule.dto.response.ScheduleDto;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/com/back/domain/schedule/schedule/checker/ScheduleAuthorizationChecker.java
+++ b/src/main/java/com/back/domain/schedule/schedule/checker/ScheduleAuthorizationChecker.java
@@ -21,7 +21,7 @@ public class ScheduleAuthorizationChecker {
      */
     @Transactional(readOnly = true)
     public boolean isActiveClubHost(Long scheduleId, Long memberId) {
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Schedule schedule = scheduleService.getActiveScheduleEntityById(scheduleId);
         Long clubId = schedule.getClub().getId();
 
         return clubChecker.isActiveClubHost(clubId, memberId);
@@ -35,7 +35,7 @@ public class ScheduleAuthorizationChecker {
      */
     @Transactional(readOnly = true)
     public boolean isActiveClubManagerOrHost(Long scheduleId, Long memberId) {
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Schedule schedule = scheduleService.getActiveScheduleEntityById(scheduleId);
         Long clubId = schedule.getClub().getId();
 
         return clubChecker.isActiveClubManagerOrHost(clubId, memberId);
@@ -49,7 +49,7 @@ public class ScheduleAuthorizationChecker {
      */
     @Transactional(readOnly = true)
     public boolean isClubMember(Long scheduleId, Long memberId) {
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Schedule schedule = scheduleService.getActiveScheduleEntityById(scheduleId);
         Long clubId = schedule.getClub().getId();
 
         return clubChecker.isClubMember(clubId, memberId);

--- a/src/main/java/com/back/domain/schedule/schedule/dto/request/ScheduleCreateReqBody.java
+++ b/src/main/java/com/back/domain/schedule/schedule/dto/request/ScheduleCreateReqBody.java
@@ -1,4 +1,4 @@
-package com.back.domain.schedule.schedule.dto;
+package com.back.domain.schedule.schedule.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;

--- a/src/main/java/com/back/domain/schedule/schedule/dto/request/ScheduleUpdateReqBody.java
+++ b/src/main/java/com/back/domain/schedule/schedule/dto/request/ScheduleUpdateReqBody.java
@@ -1,4 +1,4 @@
-package com.back.domain.schedule.schedule.dto;
+package com.back.domain.schedule.schedule.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;

--- a/src/main/java/com/back/domain/schedule/schedule/dto/response/ScheduleDetailDto.java
+++ b/src/main/java/com/back/domain/schedule/schedule/dto/response/ScheduleDetailDto.java
@@ -1,11 +1,11 @@
-package com.back.domain.schedule.schedule.dto;
+package com.back.domain.schedule.schedule.dto.response;
 
 import com.back.domain.schedule.schedule.entity.Schedule;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-public record ScheduleDto (
+public record ScheduleDetailDto(
         @Schema(description = "일정 ID")
         Long id,
         @Schema(description = "일정 제목")
@@ -23,7 +23,7 @@ public record ScheduleDto (
         @Schema(description = "체크리스트 ID", nullable = true)
         Long checkListId
 ) {
-    public ScheduleDto(Schedule schedule) {
+    public ScheduleDetailDto(Schedule schedule) {
         this(
                 schedule.getId(),
                 schedule.getTitle(),

--- a/src/main/java/com/back/domain/schedule/schedule/dto/response/ScheduleDto.java
+++ b/src/main/java/com/back/domain/schedule/schedule/dto/response/ScheduleDto.java
@@ -1,0 +1,32 @@
+package com.back.domain.schedule.schedule.dto.response;
+
+import com.back.domain.schedule.schedule.entity.Schedule;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record ScheduleDto (
+        @Schema(description = "일정 ID")
+        Long id,
+        @Schema(description = "일정 제목")
+        String title,
+        @Schema(description = "일정 시작일")
+        LocalDateTime startDate,
+        @Schema(description = "일정 종료일")
+        LocalDateTime endDate,
+        @Schema(description = "모임 ID")
+        Long clubId,
+        @Schema(description = "체크리스트 ID", nullable = true)
+        Long checkListId
+) {
+    public ScheduleDto(Schedule schedule) {
+        this(
+                schedule.getId(),
+                schedule.getTitle(),
+                schedule.getStartDate(),
+                schedule.getEndDate(),
+                schedule.getClub().getId(),
+                schedule.getCheckList() != null ? schedule.getCheckList().getId() : null
+        );
+    }
+}

--- a/src/main/java/com/back/domain/schedule/schedule/dto/response/ScheduleWithClubDto.java
+++ b/src/main/java/com/back/domain/schedule/schedule/dto/response/ScheduleWithClubDto.java
@@ -1,0 +1,35 @@
+package com.back.domain.schedule.schedule.dto.response;
+
+import com.back.domain.schedule.schedule.entity.Schedule;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record ScheduleWithClubDto(
+        @Schema(description = "일정 ID")
+        Long id,
+        @Schema(description = "일정 제목")
+        String title,
+        @Schema(description = "일정 시작일")
+        LocalDateTime startDate,
+        @Schema(description = "일정 종료일")
+        LocalDateTime endDate,
+        @Schema(description = "모임 ID")
+        Long clubId,
+        @Schema(description = "모임명")
+        String clubName,
+        @Schema(description = "체크리스트 ID", nullable = true)
+        Long checkListId
+) {
+    public ScheduleWithClubDto(Schedule schedule) {
+        this(
+                schedule.getId(),
+                schedule.getTitle(),
+                schedule.getStartDate(),
+                schedule.getEndDate(),
+                schedule.getClub().getId(),
+                schedule.getClub().getName(),
+                schedule.getCheckList() != null ? schedule.getCheckList().getId() : null
+        );
+    }
+}

--- a/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/back/domain/schedule/schedule/repository/ScheduleRepository.java
@@ -18,7 +18,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             SELECT s FROM Schedule s 
             WHERE s.club.id = :clubId 
             AND s.isActive = true 
-            AND s.startDate BETWEEN :startDateTime AND :endDateTime 
+            AND s.startDate < :endDateTime
+            AND s.endDate >= :startDateTime
             ORDER BY s.startDate
             """)
     List<Schedule> findSchedulesByClubAndDateRange(
@@ -34,7 +35,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             JOIN c.clubMembers cm
             WHERE cm.member.id = :memberId
             AND s.isActive = true
-            AND s.startDate BETWEEN :startDateTime AND :endDateTime
+            AND s.startDate < :endDateTime
+            AND s.endDate >= :startDateTime
             ORDER BY s.startDate
         """)
     List<Schedule> findMonthlySchedulesByMemberId(
@@ -47,7 +49,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("""
             SELECT s FROM Schedule s
             JOIN FETCH s.club
-            WHERE s.id = :scheduleId 
+            WHERE s.id = :scheduleId
             AND s.isActive = true
             """)
     Optional<Schedule> findActiveScheduleById(Long scheduleId);

--- a/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
@@ -1,5 +1,8 @@
 package com.back.domain.schedule.schedule.controller;
 
+import com.back.domain.schedule.schedule.dto.response.ScheduleDetailDto;
+import com.back.domain.schedule.schedule.dto.response.ScheduleDto;
+import com.back.domain.schedule.schedule.dto.response.ScheduleWithClubDto;
 import com.back.domain.schedule.schedule.entity.Schedule;
 import com.back.domain.schedule.schedule.service.ScheduleService;
 import org.hamcrest.Matchers;
@@ -44,26 +47,25 @@ class ApiV1ScheduleControllerTest {
                 .perform(get("/api/v1/schedules/clubs/" + clubId))
                 .andDo(print());
 
-        List<Schedule> schedules = scheduleService.getClubSchedules(clubId, null, null);
+        List<ScheduleDto> schedules = scheduleService.getClubSchedules(clubId, null, null);
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))
                 .andExpect(handler().methodName("getClubSchedules"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%s번 모임의 일정 목록이 조회되었습니다.".formatted(clubId)))
+                .andExpect(jsonPath("$.message").value("일정 목록이 조회되었습니다."))
                 .andExpect(jsonPath("$.data.length()").value(schedules.size()));
 
         for (int i = 0; i < schedules.size(); i++) {
-            Schedule schedule = schedules.get(i);
+            ScheduleDto schedule = schedules.get(i);
 
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.getId()))
-                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.getTitle()))
-                    .andExpect(jsonPath("$.data[%d].content".formatted(i)).value(schedule.getContent()))
-                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$.data[%d].spot".formatted(i)).value(schedule.getSpot()));
+                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.id()))
+                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.title()))
+                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.startDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.endDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].clubId".formatted(i)).value(schedule.clubId()));
         }
     }
 
@@ -81,26 +83,25 @@ class ApiV1ScheduleControllerTest {
                         .param("endDate", endDateStr))
                 .andDo(print());
 
-        List<Schedule> schedules = scheduleService.getClubSchedules(clubId, LocalDate.parse(startDateStr), LocalDate.parse(endDateStr));
+        List<ScheduleDto> schedules = scheduleService.getClubSchedules(clubId, LocalDate.parse(startDateStr), LocalDate.parse(endDateStr));
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))
                 .andExpect(handler().methodName("getClubSchedules"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%s번 모임의 일정 목록이 조회되었습니다.".formatted(clubId)))
+                .andExpect(jsonPath("$.message").value("일정 목록이 조회되었습니다."))
                 .andExpect(jsonPath("$.data.length()").value(schedules.size()));
 
         for (int i = 0; i < schedules.size(); i++) {
-            Schedule schedule = schedules.get(i);
+            ScheduleDto schedule = schedules.get(i);
 
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.getId()))
-                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.getTitle()))
-                    .andExpect(jsonPath("$.data[%d].content".formatted(i)).value(schedule.getContent()))
-                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$.data[%d].spot".formatted(i)).value(schedule.getSpot()));
+                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.id()))
+                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.title()))
+                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.startDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.endDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].clubId".formatted(i)).value(schedule.clubId()));
         }
     }
 
@@ -117,26 +118,25 @@ class ApiV1ScheduleControllerTest {
                         .param("startDate", startDateStr))
                 .andDo(print());
 
-        List<Schedule> schedules = scheduleService.getClubSchedules(clubId, LocalDate.parse(startDateStr), LocalDate.parse(endDateStr));
+        List<ScheduleDto> schedules = scheduleService.getClubSchedules(clubId, LocalDate.parse(startDateStr), LocalDate.parse(endDateStr));
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))
                 .andExpect(handler().methodName("getClubSchedules"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%s번 모임의 일정 목록이 조회되었습니다.".formatted(clubId)))
+                .andExpect(jsonPath("$.message").value("일정 목록이 조회되었습니다."))
                 .andExpect(jsonPath("$.data.length()").value(schedules.size()));
 
         for (int i = 0; i < schedules.size(); i++) {
-            Schedule schedule = schedules.get(i);
+            ScheduleDto schedule = schedules.get(i);
 
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.getId()))
-                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.getTitle()))
-                    .andExpect(jsonPath("$.data[%d].content".formatted(i)).value(schedule.getContent()))
-                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$.data[%d].spot".formatted(i)).value(schedule.getSpot()));
+                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.id()))
+                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.title()))
+                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.startDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.endDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].clubId".formatted(i)).value(schedule.clubId()));
         }
     }
 
@@ -166,20 +166,22 @@ class ApiV1ScheduleControllerTest {
                 .perform(get("/api/v1/schedules/" + scheduleId))
                 .andDo(print());
 
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        ScheduleDetailDto schedule = scheduleService.getActiveScheduleById(scheduleId);
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))
                 .andExpect(handler().methodName("getSchedule"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%s번 일정이 조회되었습니다.".formatted(scheduleId)))
-                .andExpect(jsonPath("$.data.id").value(schedule.getId()))
-                .andExpect(jsonPath("$.data.title").value(schedule.getTitle()))
-                .andExpect(jsonPath("$.data.content").value(schedule.getContent()))
-                .andExpect(jsonPath("$.data.startDate").value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
-                .andExpect(jsonPath("$.data.endDate").value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
-                .andExpect(jsonPath("$.data.spot").value(schedule.getSpot()));
+                .andExpect(jsonPath("$.message").value("일정이 조회되었습니다.".formatted(scheduleId)))
+                .andExpect(jsonPath("$.data.id").value(schedule.id()))
+                .andExpect(jsonPath("$.data.title").value(schedule.title()))
+                .andExpect(jsonPath("$.data.content").value(schedule.content()))
+                .andExpect(jsonPath("$.data.startDate").value(Matchers.startsWith(schedule.startDate().toString().substring(0, 16))))
+                .andExpect(jsonPath("$.data.endDate").value(Matchers.startsWith(schedule.endDate().toString().substring(0, 16))))
+                .andExpect(jsonPath("$.data.spot").value(schedule.spot()))
+                .andExpect(jsonPath("$.data.clubId").value(schedule.clubId()))
+                .andExpect(jsonPath("$.data.checkListId").value(schedule.checkListId()));
     }
 
     @Test
@@ -220,20 +222,22 @@ class ApiV1ScheduleControllerTest {
                 )
                 .andDo(print());
 
-        Schedule schedule = scheduleService.getLatestClubSchedule(clubId);
+        ScheduleDetailDto schedule = scheduleService.getLatestClubSchedule(clubId);
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))
                 .andExpect(handler().methodName("createSchedule"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.code").value(201))
-                .andExpect(jsonPath("$.message").value("%d번 일정이 생성되었습니다.".formatted(schedule.getId())))
-                .andExpect(jsonPath("$.data.id").value(schedule.getId()))
-                .andExpect(jsonPath("$.data.title").value(schedule.getTitle()))
-                .andExpect(jsonPath("$.data.content").value(schedule.getContent()))
-                .andExpect(jsonPath("$.data.startDate").value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
-                .andExpect(jsonPath("$.data.endDate").value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
-                .andExpect(jsonPath("$.data.spot").value(schedule.getSpot()));
+                .andExpect(jsonPath("$.message").value("일정이 생성되었습니다."))
+                .andExpect(jsonPath("$.data.id").value(schedule.id()))
+                .andExpect(jsonPath("$.data.title").value(schedule.title()))
+                .andExpect(jsonPath("$.data.content").value(schedule.content()))
+                .andExpect(jsonPath("$.data.startDate").value(Matchers.startsWith(schedule.startDate().toString().substring(0, 16))))
+                .andExpect(jsonPath("$.data.endDate").value(Matchers.startsWith(schedule.endDate().toString().substring(0, 16))))
+                .andExpect(jsonPath("$.data.spot").value(schedule.spot()))
+                .andExpect(jsonPath("$.data.clubId").value(schedule.clubId()))
+                .andExpect(jsonPath("$.data.checkListId").value(schedule.checkListId()));
     }
 
     @Test
@@ -313,20 +317,22 @@ class ApiV1ScheduleControllerTest {
                 )
                 .andDo(print());
 
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        ScheduleDetailDto schedule = scheduleService.getActiveScheduleById(scheduleId);
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))
                 .andExpect(handler().methodName("modifySchedule"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%d번 일정이 수정되었습니다.".formatted(schedule.getId())))
-                .andExpect(jsonPath("$.data.id").value(schedule.getId()))
-                .andExpect(jsonPath("$.data.title").value(schedule.getTitle()))
-                .andExpect(jsonPath("$.data.content").value(schedule.getContent()))
-                .andExpect(jsonPath("$.data.startDate").value(Matchers.startsWith(schedule.getStartDate().toString())))
-                .andExpect(jsonPath("$.data.endDate").value(Matchers.startsWith(schedule.getEndDate().toString())))
-                .andExpect(jsonPath("$.data.spot").value(schedule.getSpot()));
+                .andExpect(jsonPath("$.message").value("일정이 수정되었습니다."))
+                .andExpect(jsonPath("$.data.id").value(schedule.id()))
+                .andExpect(jsonPath("$.data.title").value(schedule.title()))
+                .andExpect(jsonPath("$.data.content").value(schedule.content()))
+                .andExpect(jsonPath("$.data.startDate").value(Matchers.startsWith(schedule.startDate().toString())))
+                .andExpect(jsonPath("$.data.endDate").value(Matchers.startsWith(schedule.endDate().toString())))
+                .andExpect(jsonPath("$.data.spot").value(schedule.spot()))
+                .andExpect(jsonPath("$.data.clubId").value(schedule.clubId()))
+                .andExpect(jsonPath("$.data.checkListId").value(schedule.checkListId()));
     }
 
     @Test
@@ -350,20 +356,22 @@ class ApiV1ScheduleControllerTest {
                 )
                 .andDo(print());
 
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        ScheduleDetailDto schedule = scheduleService.getActiveScheduleById(scheduleId);
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))
                 .andExpect(handler().methodName("modifySchedule"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%d번 일정이 수정되었습니다.".formatted(schedule.getId())))
-                .andExpect(jsonPath("$.data.id").value(schedule.getId()))
-                .andExpect(jsonPath("$.data.title").value(schedule.getTitle()))
-                .andExpect(jsonPath("$.data.content").value(schedule.getContent()))
-                .andExpect(jsonPath("$.data.startDate").value(Matchers.startsWith(schedule.getStartDate().toString())))
-                .andExpect(jsonPath("$.data.endDate").value(Matchers.startsWith(schedule.getEndDate().toString())))
-                .andExpect(jsonPath("$.data.spot").value(schedule.getSpot()));
+                .andExpect(jsonPath("$.message").value("일정이 수정되었습니다."))
+                .andExpect(jsonPath("$.data.id").value(schedule.id()))
+                .andExpect(jsonPath("$.data.title").value(schedule.title()))
+                .andExpect(jsonPath("$.data.content").value(schedule.content()))
+                .andExpect(jsonPath("$.data.startDate").value(Matchers.startsWith(schedule.startDate().toString())))
+                .andExpect(jsonPath("$.data.endDate").value(Matchers.startsWith(schedule.endDate().toString())))
+                .andExpect(jsonPath("$.data.spot").value(schedule.spot()))
+                .andExpect(jsonPath("$.data.clubId").value(schedule.clubId()))
+                .andExpect(jsonPath("$.data.checkListId").value(schedule.checkListId()));
     }
 
     @Test
@@ -454,7 +462,7 @@ class ApiV1ScheduleControllerTest {
     @WithUserDetails(value = "hgd222@test.com") // 모임장 계정
     void td1() throws Exception {
         Long scheduleId = 6L;
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Schedule schedule = scheduleService.getActiveScheduleEntityById(scheduleId);
 
         Long clubId = schedule.getClub().getId();
         long preCnt = scheduleService.countClubSchedules(clubId);
@@ -468,7 +476,7 @@ class ApiV1ScheduleControllerTest {
                 .andExpect(handler().methodName("deleteSchedule"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%d번 일정이 삭제되었습니다.".formatted(scheduleId)));
+                .andExpect(jsonPath("$.message").value("일정이 삭제되었습니다."));
 
         long afterCnt = scheduleService.countClubSchedules(clubId);
         assertThat(afterCnt).isEqualTo(preCnt - 1);
@@ -479,7 +487,7 @@ class ApiV1ScheduleControllerTest {
     @WithUserDetails(value = "hgd222@test.com") // 모임장 계정
     void td2() throws Exception {
         Long scheduleId = 5L;
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Schedule schedule = scheduleService.getActiveScheduleEntityById(scheduleId);
 
         Long clubId = schedule.getClub().getId();
         long preCnt = scheduleService.countClubSchedules(clubId);
@@ -493,13 +501,13 @@ class ApiV1ScheduleControllerTest {
                 .andExpect(handler().methodName("deleteSchedule"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%d번 일정이 삭제되었습니다.".formatted(scheduleId)));
+                .andExpect(jsonPath("$.message").value("일정이 삭제되었습니다.".formatted(scheduleId)));
 
         // 일정이 삭제가 아닌 비활성화 되었는지 확인
         long afterCnt = scheduleService.countClubSchedules(clubId);
         assertThat(afterCnt).isEqualTo(preCnt);
 
-        Schedule updatedSchedule = scheduleService.getScheduleById(scheduleId);
+        Schedule updatedSchedule = scheduleService.getScheduleEntityById(scheduleId);
         assertThat(updatedSchedule.isActive()).isFalse();
 
         // 체크리스트가 비활성화 되었는지 확인
@@ -513,7 +521,7 @@ class ApiV1ScheduleControllerTest {
     @WithUserDetails(value = "pms4@test.com") // 모임 참여자 계정
     void td3() throws Exception {
         Long scheduleId = 6L;
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Schedule schedule = scheduleService.getActiveScheduleEntityById(scheduleId);
 
         Long clubId = schedule.getClub().getId();
 
@@ -532,7 +540,7 @@ class ApiV1ScheduleControllerTest {
     @WithUserDetails(value = "chs4s@test.com") // 모임 참여자가 아닌 계정
     void td4() throws Exception {
         Long scheduleId = 6L;
-        Schedule schedule = scheduleService.getActiveScheduleById(scheduleId);
+        Schedule schedule = scheduleService.getActiveScheduleEntityById(scheduleId);
 
         Long clubId = schedule.getClub().getId();
 
@@ -559,7 +567,7 @@ class ApiV1ScheduleControllerTest {
                         .param("endDate", endDateStr))
                 .andDo(print());
 
-        List<Schedule> schedules = scheduleService.getMySchedules(1L, LocalDate.parse(startDateStr), LocalDate.parse(endDateStr));
+        List<ScheduleWithClubDto> schedules = scheduleService.getMySchedules(1L, LocalDate.parse(startDateStr), LocalDate.parse(endDateStr));
 
         resultActions
                 .andExpect(handler().handlerType(ApiV1ScheduleController.class))
@@ -570,15 +578,16 @@ class ApiV1ScheduleControllerTest {
                 .andExpect(jsonPath("$.data.length()").value(schedules.size()));
 
         for (int i = 0; i < schedules.size(); i++) {
-            Schedule schedule = schedules.get(i);
+            ScheduleWithClubDto schedule = schedules.get(i);
 
             resultActions
-                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.getId()))
-                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.getTitle()))
-                    .andExpect(jsonPath("$.data[%d].content".formatted(i)).value(schedule.getContent()))
-                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.getStartDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.getEndDate().toString().substring(0, 16))))
-                    .andExpect(jsonPath("$.data[%d].spot".formatted(i)).value(schedule.getSpot()));
+                    .andExpect(jsonPath("$.data[%d].id".formatted(i)).value(schedule.id()))
+                    .andExpect(jsonPath("$.data[%d].title".formatted(i)).value(schedule.title()))
+                    .andExpect(jsonPath("$.data[%d].startDate".formatted(i)).value(Matchers.startsWith(schedule.startDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].endDate".formatted(i)).value(Matchers.startsWith(schedule.endDate().toString().substring(0, 16))))
+                    .andExpect(jsonPath("$.data[%d].clubId".formatted(i)).value(schedule.clubId()))
+                    .andExpect(jsonPath("$.data[%d].clubName".formatted(i)).value(schedule.clubName()));
+            ;
         }
     }
 }


### PR DESCRIPTION
## 📢 기능 설명
- 캘린더에 맞춰 시작일, 종료일 받을 수 있게 쿼리 수정
- 일정 dto 세분화
- 일정 서비스 dto 반환으로 변경

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #169 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 일정 상세 정보와 클럽 정보를 포함한 새로운 DTO(ScheduleDetailDto, ScheduleWithClubDto)가 추가되었습니다.

* **변경 사항**
  * 일정 관련 API 응답이 엔티티 대신 DTO로 일관되게 반환됩니다.
  * 일정 목록, 상세 조회, 생성, 수정, 삭제 시 반환되는 데이터 구조가 개선되었습니다.
  * 일정 조회 시 내용(content)과 장소(spot) 필드는 일부 응답에서 제외되었습니다.
  * 일정 조회 시 날짜 범위 필터링 로직이 개선되어, 기간이 겹치는 일정도 조회됩니다.

* **버그 수정**
  * 일정 API의 날짜 범위 처리 방식이 더 정확하게 동작하도록 수정되었습니다.

* **테스트**
  * 컨트롤러 테스트가 DTO 기반으로 리팩터링되어, 실제 사용자 응답과 일치하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->