### PR TITLE
 [refactor] 공개 모임 목록 반환 api 개선

### DIFF
--- a/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
+++ b/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
@@ -82,10 +82,10 @@ public class ApiV1ClubController {
 
     @GetMapping("/public")
     @Operation(summary = "공개 클럽 목록 조회 (페이징 가능)")
-    public RsData<Page<ClubControllerDtos.SimpleClubInfoResponse>> getPublicClubs(
+    public RsData<Page<ClubControllerDtos.SimpleClubInfoWithoutLeader>> getPublicClubs(
             @ParameterObject Pageable pageable
     ) {
-        Page<ClubControllerDtos.SimpleClubInfoResponse> response = clubService.getPublicClubs(pageable);
+        Page<ClubControllerDtos.SimpleClubInfoWithoutLeader> response = clubService.getPublicClubs(pageable);
         return new RsData<>(200, "공개 클럽 목록이 조회됐습니다.", response);
     }
 }

--- a/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
+++ b/src/main/java/com/back/domain/club/club/controller/ApiV1ClubController.java
@@ -3,6 +3,8 @@ package com.back.domain.club.club.controller;
 import com.back.domain.club.club.dtos.ClubControllerDtos;
 import com.back.domain.club.club.entity.Club;
 import com.back.domain.club.club.service.ClubService;
+import com.back.global.enums.ClubCategory;
+import com.back.global.enums.EventType;
 import com.back.global.rsData.RsData;
 import com.back.global.security.SecurityUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -83,9 +85,13 @@ public class ApiV1ClubController {
     @GetMapping("/public")
     @Operation(summary = "공개 클럽 목록 조회 (페이징 가능)")
     public RsData<Page<ClubControllerDtos.SimpleClubInfoWithoutLeader>> getPublicClubs(
-            @ParameterObject Pageable pageable
+            @ParameterObject Pageable pageable,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String mainSpot,
+            @RequestParam(required = false) ClubCategory category,
+            @RequestParam(required = false) EventType eventType
     ) {
-        Page<ClubControllerDtos.SimpleClubInfoWithoutLeader> response = clubService.getPublicClubs(pageable);
+        Page<ClubControllerDtos.SimpleClubInfoWithoutLeader> response = clubService.getPublicClubs(pageable, name, mainSpot, category, eventType);
         return new RsData<>(200, "공개 클럽 목록이 조회됐습니다.", response);
     }
 }

--- a/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
+++ b/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
@@ -115,6 +115,7 @@ public class ClubControllerDtos {
             String mainSpot,
             String eventType,
             String startDate,
-            String endDate
+            String endDate,
+            String bio
     ) {}
 }

--- a/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
+++ b/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
@@ -106,4 +106,15 @@ public class ClubControllerDtos {
             Long leaderId,
             String leaderName
     ) {}
+
+    public static record SimpleClubInfoWithoutLeader(
+            Long clubId,
+            String name,
+            String category,
+            String imageUrl,
+            String mainSpot,
+            String eventType,
+            String startDate,
+            String endDate
+    ) {}
 }

--- a/src/main/java/com/back/domain/club/club/repository/ClubRepository.java
+++ b/src/main/java/com/back/domain/club/club/repository/ClubRepository.java
@@ -4,12 +4,13 @@ import com.back.domain.club.club.entity.Club;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface ClubRepository extends JpaRepository<Club, Long> {
+public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificationExecutor<Club> {
     /**
      * 마지막으로 생성된 클럽을 반환합니다.
      * @return 마지막으로 생성된 클럽

--- a/src/main/java/com/back/domain/club/club/repository/ClubSpecification.java
+++ b/src/main/java/com/back/domain/club/club/repository/ClubSpecification.java
@@ -1,0 +1,55 @@
+// com.back.domain.club.club.repository 아래에 ClubSpecification.java 생성
+package com.back.domain.club.club.repository;
+
+import com.back.domain.club.club.entity.Club;
+import com.back.global.enums.ClubCategory;
+import com.back.global.enums.EventType;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+
+public class ClubSpecification {
+
+    // 이름(name)으로 부분 일치 검색
+    public static Specification<Club> likeName(String name) {
+        // name 파라미터가 비어있지 않은 경우에만 Specification을 반환
+        if (!StringUtils.hasText(name)) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.like(root.get("name"), "%" + name + "%");
+    }
+
+    // 지역(mainSpot)으로 부분 일치 검색
+    public static Specification<Club> likeMainSpot(String mainSpot) {
+        if (!StringUtils.hasText(mainSpot)) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.like(root.get("mainSpot"), "%" + mainSpot + "%");
+    }
+
+    // 카테고리(category)로 완전 일치 검색
+    public static Specification<Club> equalCategory(ClubCategory category) {
+        // category가 null이 아닌 경우에만 Specification을 반환
+        if (category == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("category"), category);
+    }
+
+    // 모집 유형(eventType)으로 완전 일치 검색
+    public static Specification<Club> equalEventType(EventType eventType) {
+        if (eventType == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("eventType"), eventType);
+    }
+
+    // 공개된 클럽만 조회하는 기본 조건
+    public static Specification<Club> isPublic() {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.isTrue(root.get("isPublic"));
+    }
+}

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -295,7 +295,8 @@ public class ClubService {
                         club.getMainSpot(),
                         club.getEventType().toString(),
                         club.getStartDate().toString(),
-                        club.getEndDate().toString()
+                        club.getEndDate().toString(),
+                        club.getBio()
                 ));
     }
 

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -253,9 +253,9 @@ public class ClubService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ClubControllerDtos.SimpleClubInfoResponse> getPublicClubs(Pageable pageable) {
+    public Page<ClubControllerDtos.SimpleClubInfoWithoutLeader> getPublicClubs(Pageable pageable) {
         return clubRepository.findAllByIsPublicTrue(pageable)
-                .map(club -> new ClubControllerDtos.SimpleClubInfoResponse(
+                .map(club -> new ClubControllerDtos.SimpleClubInfoWithoutLeader(
                         club.getId(),
                         club.getName(),
                         club.getCategory().toString(),
@@ -263,11 +263,7 @@ public class ClubService {
                         club.getMainSpot(),
                         club.getEventType().toString(),
                         club.getStartDate().toString(),
-                        club.getEndDate().toString(),
-                        club.getLeaderId(),
-                        memberService.findMemberById(club.getLeaderId())
-                                .map(Member::getNickname)
-                                .orElse("Unknown Leader")
+                        club.getEndDate().toString()
                 ));
     }
 

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -61,7 +61,6 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                 "/api/v1/members/auth/register",
                 "/api/v1/members/auth/guest-register",
                 "/api/v1/members/auth/guest-login",
-                "/api/v1/clubs/{clubId}",
                 "/api/v1/clubs/public"
         ).contains(request.getRequestURI())) {
             filterChain.doFilter(request, response);

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -56,7 +56,14 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
         }
 
         // 인증, 인가가 필요없는 API 요청이라면 패스
-        if (List.of("/api/v1/members/auth/login", "/api/v1/members/auth/register").contains(request.getRequestURI())) {
+        if (List.of(
+                "/api/v1/members/auth/login",
+                "/api/v1/members/auth/register",
+                "/api/v1/members/auth/guest-register",
+                "/api/v1/members/auth/guest-login",
+                "/api/v1/clubs/{clubId}",
+                "/api/v1/clubs/public"
+        ).contains(request.getRequestURI())) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
+++ b/src/test/java/com/back/domain/club/club/controller/ApiV1ClubControllerTest.java
@@ -740,8 +740,6 @@ class ApiV1ClubControllerTest {
                 .andExpect(jsonPath("$.data.content[0].eventType").value(club1.getEventType().name()))
                 .andExpect(jsonPath("$.data.content[0].startDate").value(club1.getStartDate().toString()))
                 .andExpect(jsonPath("$.data.content[0].endDate").value(club1.getEndDate().toString()))
-                .andExpect(jsonPath("$.data.content[0].leaderId").value(club1.getLeaderId()))
-                .andExpect(jsonPath("$.data.content[0].leaderName").value("홍길동"))
 
                 .andExpect(jsonPath("$.data.content[1].clubId").value(club2.getId()))
                 .andExpect(jsonPath("$.data.content[1].name").value(club2.getName()))
@@ -750,9 +748,7 @@ class ApiV1ClubControllerTest {
                 .andExpect(jsonPath("$.data.content[1].mainSpot").value(club2.getMainSpot()))
                 .andExpect(jsonPath("$.data.content[1].eventType").value(club2.getEventType().name()))
                 .andExpect(jsonPath("$.data.content[1].startDate").value(club2.getStartDate().toString()))
-                .andExpect(jsonPath("$.data.content[1].endDate").value(club2.getEndDate().toString()))
-                .andExpect(jsonPath("$.data.content[1].leaderId").value(club2.getLeaderId()))
-                .andExpect(jsonPath("$.data.content[1].leaderName").value("최지우"));
+                .andExpect(jsonPath("$.data.content[1].endDate").value(club2.getEndDate().toString()));
     }
 
 


### PR DESCRIPTION
## 📢 기능 설명
- 공개 모임 목록 반환 API에 필터링 기능 추가
- leader 정보는 반환하지 않도록 변경
- security에서 몇몇 api를 막지 않도록 변경
<br>

## 연결된 issue
close #175
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 공개 클럽 목록 조회 시 이름, 주요 위치, 카테고리, 이벤트 유형으로 필터링할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 공개 클럽 목록 응답에서 클럽장 정보가 제외되고 클럽 소개(bio) 정보가 추가되었습니다.

* **테스트**
  * 클럽장 정보 관련 테스트 검증이 제거되어 실제 응답 구조와 일치하도록 수정되었습니다.

* **기타**
  * 일부 클럽 관련 API와 게스트 회원가입/로그인 API가 인증 없이 접근 가능하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->