### PR TITLE
[hotfix] clubInfo 반환 리팩토링

### DIFF
--- a/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
+++ b/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
@@ -90,7 +90,8 @@ public class ClubControllerDtos {
             Boolean isPublic,
             String imageUrl,
             Long leaderId,
-            String leaderName
+            String leaderName,
+            boolean state
     ) {
     }
 

--- a/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
+++ b/src/main/java/com/back/domain/club/club/dtos/ClubControllerDtos.java
@@ -90,8 +90,7 @@ public class ClubControllerDtos {
             Boolean isPublic,
             String imageUrl,
             Long leaderId,
-            String leaderName,
-            boolean state
+            String leaderName
     ) {
     }
 

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -267,8 +267,7 @@ public class ClubService {
                 club.isPublic(),
                 club.getImageUrl(),
                 club.getLeaderId(),
-                leader.getNickname(),
-                club.isState()
+                leader.getNickname()
         );
     }
 

--- a/src/main/java/com/back/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/back/domain/club/club/service/ClubService.java
@@ -248,6 +248,11 @@ public class ClubService {
             }
         }
 
+        // 비활성화된 클럽인 경우 예외 처리
+        if (!club.isState()) {
+            throw new ServiceException(404, "해당 클럽은 비활성화 상태입니다.");
+        }
+
         return new ClubControllerDtos.ClubInfoResponse(
                 club.getId(),
                 club.getName(),
@@ -262,7 +267,8 @@ public class ClubService {
                 club.isPublic(),
                 club.getImageUrl(),
                 club.getLeaderId(),
-                leader.getNickname()
+                leader.getNickname(),
+                club.isState()
         );
     }
 


### PR DESCRIPTION
## 📢 기능 설명
- 클럽 정보 반환 시 responsebody에 state(활성화 상태) 포함
- 클럽 정보 반환 시 활성화 여부 체크
<br>

## 연결된 issue
없음
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 비활성화된 클럽에 접근 시 더 이상 정보를 조회할 수 없으며, 404 오류와 함께 클럽이 비활성화되었음을 안내하는 메시지가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->