### PR TITLE
[hotfix] 모임 가입 신청 로직 수정

### DIFF
--- a/src/main/java/com/back/domain/club/clubMember/service/MyClubService.java
+++ b/src/main/java/com/back/domain/club/clubMember/service/MyClubService.java
@@ -88,6 +88,12 @@ public class MyClubService {
                 throw new ServiceException(400, "이미 가입 신청 상태입니다.");
             else if (existingMember.getState() == ClubMemberState.INVITED)
                 throw new ServiceException(400, "클럽 초대 상태입니다. 초대를 수락해주세요.");
+            else if (existingMember.getState() == ClubMemberState.WITHDRAWN){
+                // 탈퇴 상태면, 기존 클럽 멤버를 가져와서 APPLYING 상태로 변경
+                existingMember.updateState(ClubMemberState.APPLYING); // 상태를 APPLYING으로 변경
+                clubMemberRepository.save(existingMember); // 클럽 멤버 저장
+                return club; // 클럽 반환
+            }
         }
 
         // 클럽 멤버 생성 및 저장


### PR DESCRIPTION
## 📢 기능 설명
- 기존에 탈퇴 상태였다면, 새로 ClubMember 생성하지 않고, 기존 ClubMember 상태를 가입 신청으로 바꾼다.
<br>

## 연결된 issue
없음
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 탈퇴한 동아리 회원이 재신청할 경우, 기존 회원 상태를 '신청 중'으로 변경하여 정상적으로 재가입할 수 있도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->