### PR TITLE
[refactor] 매니저도 일정 생성, 삭제 가능하게 변경

### DIFF
--- a/src/main/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleController.java
+++ b/src/main/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleController.java
@@ -63,8 +63,8 @@ public class ApiV1ScheduleController {
     }
 
     @PostMapping
-    @Operation(summary = "일정 생성", description = "일정 생성은 호스트 권한이 있는 사용자만 가능")
-    @PreAuthorize("@clubAuthorizationChecker.isActiveClubHost(#reqBody.clubId, #user.getId())")
+    @Operation(summary = "일정 생성", description = "일정 생성은 호스트 또는 매니저 권한이 있는 사용자만 가능")
+    @PreAuthorize("@clubAuthorizationChecker.isActiveClubManagerOrHost(#reqBody.clubId, #user.getId())")
     public RsData<ScheduleDetailDto> createSchedule(
             @Valid @RequestBody ScheduleCreateReqBody reqBody,
             @AuthenticationPrincipal SecurityUser user
@@ -97,8 +97,8 @@ public class ApiV1ScheduleController {
     }
 
     @DeleteMapping("{scheduleId}")
-    @Operation(summary = "일정 삭제")
-    @PreAuthorize("@scheduleAuthorizationChecker.isActiveClubHost(#scheduleId, #user.getId())")
+    @Operation(summary = "일정 삭제", description = "일정 삭제는 호스트 또는 매니저 권한이 있는 사용자만 가능")
+    @PreAuthorize("@scheduleAuthorizationChecker.isActiveClubManagerOrHost(#scheduleId, #user.getId())")
     public RsData<Void> deleteSchedule(
             @PathVariable Long scheduleId,
             @AuthenticationPrincipal SecurityUser user

--- a/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
+++ b/src/test/java/com/back/domain/schedule/schedule/controller/ApiV1ScheduleControllerTest.java
@@ -269,8 +269,8 @@ class ApiV1ScheduleControllerTest {
     }
 
     @Test
-    @DisplayName("일정 생성 - 모임장이 아닌 매니저/참여자인 경우 예외 처리")
-    @WithUserDetails(value = "chs4s@test.com") // 매니저 계정
+    @DisplayName("일정 생성 - 모임장/매니저가 아닌 참여자인 경우 예외 처리")
+    @WithUserDetails(value = "lyh3@test.com") // 참여자 계정
     void tc3() throws Exception {
         Long clubId = 1L;
 
@@ -517,7 +517,7 @@ class ApiV1ScheduleControllerTest {
     }
 
     @Test
-    @DisplayName("일정 삭제 - 모임장이 아닌 경우 예외 처리")
+    @DisplayName("일정 삭제 - 모임장/매니저가 아닌 경우 예외 처리")
     @WithUserDetails(value = "pms4@test.com") // 모임 참여자 계정
     void td3() throws Exception {
         Long scheduleId = 6L;


### PR DESCRIPTION
## 📢 기능 설명
- 매니저도 일정 생성, 삭제 가능하게 변경

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #176 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 일정 생성 및 삭제 권한이 기존 호스트에서 매니저까지 확대되었습니다. 이제 호스트와 매니저 모두 일정을 생성하거나 삭제할 수 있습니다.

* **문서**
  * 일정 생성 및 삭제 권한에 대한 안내 문구가 호스트와 매니저 모두 가능하도록 수정되었습니다.

* **테스트**
  * 권한 관련 테스트의 사용자 역할 및 설명이 실제 동작에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->